### PR TITLE
Implement async optimization endpoint

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -157,3 +157,38 @@ def save_execution_result(demand_matrix, params, coverage, total_agents, executi
     save_learning_data(data)
     return True
 
+
+def run_complete_optimization(file_stream, config):
+    """Run the simplified optimization workflow.
+
+    Parameters
+    ----------
+    file_stream: file-like
+        Excel file uploaded by the user.
+    config: dict
+        Dictionary with all configuration fields from the UI. The current
+        implementation only uses this parameter for future extensions.
+
+    Returns
+    -------
+    dict
+        Mapping containing the optimization metrics, heatmap images and the
+        generated Excel bytes.
+    """
+    demand_matrix = load_demand_excel(file_stream)
+    patterns = next(generate_shifts_coverage_corrected())
+    assignments = solve_in_chunks_optimized(patterns, demand_matrix)
+    metrics = analyze_results(assignments, patterns, demand_matrix)
+    schedule = metrics["total_coverage"] if metrics else demand_matrix
+
+    cov_img = heatmap(schedule, "Cobertura").getvalue()
+    dem_img = heatmap(demand_matrix, "Demanda").getvalue()
+    excel_bytes = export_detailed_schedule(assignments, patterns)
+
+    return {
+        "metrics": metrics,
+        "coverage_image": cov_img,
+        "demand_image": dem_img,
+        "excel_bytes": excel_bytes,
+    }
+

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -25,3 +25,30 @@ bindRange('coverage', 'cov_val');
 bindRange('break_from_start', 'bstart_val');
 bindRange('break_from_end', 'bend_val');
 
+const form = document.getElementById('genForm');
+const results = document.getElementById('results');
+const agents = document.getElementById('agents');
+const coverage = document.getElementById('coverage');
+const demandImg = document.getElementById('demand_img');
+const resultImg = document.getElementById('result_img');
+const downloadLink = document.getElementById('download_link');
+const excelLink = document.getElementById('excel_link');
+
+if (form) {
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const data = new FormData(form);
+    const res = await fetch(form.action, {method: 'POST', body: data});
+    const json = await res.json();
+    if (json.metrics) {
+      agents.textContent = `Agentes estimados: ${json.metrics.total_agents}`;
+      coverage.textContent = `Cobertura: ${json.metrics.coverage_percentage.toFixed(1)}%`;
+    }
+    demandImg.src = 'data:image/png;base64,' + json.demand_image;
+    resultImg.src = 'data:image/png;base64,' + json.coverage_image;
+    excelLink.href = json.excel_url;
+    downloadLink.style.display = 'block';
+    results.style.display = 'block';
+  });
+}
+

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -98,16 +98,14 @@
   <a href="{{ url_for('logout') }}" class="btn btn-secondary mt-3">Salir</a>
 </form>
 
-{% if metrics %}
+<div id="results" style="display:none">
   <hr>
   <h4>Resultados</h4>
-  <p>Agentes estimados: {{ metrics.total_agents }}</p>
-  <p>Cobertura: {{ '%.1f'|format(metrics.coverage_percentage) }}%</p>
-  <img src="{{ demand_url }}" class="img-fluid" alt="demand">
-  <img src="{{ image_url }}" class="img-fluid" alt="schedule">
-  {% if download %}
-  <p class="mt-2"><a class="btn btn-success" href="{{ url_for('download') }}">Descargar Excel</a></p>
-  {% endif %}
-{% endif %}
+  <p id="agents"></p>
+  <p id="coverage"></p>
+  <img id="demand_img" class="img-fluid" alt="demand">
+  <img id="result_img" class="img-fluid" alt="schedule">
+  <p class="mt-2" id="download_link" style="display:none"><a class="btn btn-success" id="excel_link" href="#">Descargar Excel</a></p>
+</div>
 <script src="{{ url_for('static', filename='js/generador.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add scheduler.run_complete_optimization
- update `/generador` route to parse all form options and return JSON
- store generated Excel bytes in session and stream them in `/download_excel`
- make generator page dynamic via JavaScript and update link to new route

## Testing
- `python -m py_compile website/app.py website/scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_6884312559308327ab148c3e39834e68