### PR TITLE
Add styling to generador page

### DIFF
--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -1,5 +1,53 @@
 {% extends 'base.html' %}
 {% block content %}
+<style>
+  /* page specific styles */
+
+  .alert-info {
+    background-color: #d9ecff;
+    color: #055160;
+    border-color: #b6effb;
+  }
+
+  .metric-card {
+    border: 1px solid #dee2e6;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    background-color: #fff;
+  }
+
+  .btn-danger {
+    background-color: #dc3545;
+    border-color: #dc3545;
+  }
+
+  .nav-tabs .nav-link.active {
+    background-color: #f8f9fa;
+    font-weight: bold;
+  }
+
+  .table-striped > tbody > tr:nth-of-type(odd) > td {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  .progress-bar {
+    background-color: #0d6efd;
+  }
+
+  .config-section {
+    margin-bottom: 1.5rem;
+  }
+
+  .form-range::-webkit-slider-thumb {
+    background-color: #0d6efd;
+  }
+
+  .form-check-input:checked {
+    background-color: #0d6efd;
+    border-color: #0d6efd;
+  }
+</style>
 <h2>Generador de Horarios</h2>
 <form method="post" enctype="multipart/form-data" id="genForm">
   <div class="mb-3">


### PR DESCRIPTION
## Summary
- style the generator page with Bootstrap-inspired rules

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6884312fbd7c8327866f897a9cd94d33