### PR TITLE
Add configurable scheduling options

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -109,24 +109,26 @@ document.getElementById('pt').addEventListener('change', togglePTOptions);
 
 /* Intercept form submission and send via fetch. */
 const form = document.getElementById('genForm');
+const progressContainer = document.getElementById('progress-container');
+const progressBar = document.getElementById('progressBar');
 if (form) {
   form.addEventListener('submit', async (ev) => {
     ev.preventDefault();
-    const progress = document.getElementById('progress') || (() => {
-      const p = document.createElement('div');
-      p.id = 'progress';
-      form.after(p);
-      return p;
-    })();
-    progress.textContent = 'Generando...';
+    if (progressContainer && progressBar) {
+      progressContainer.style.display = 'block';
+      progressBar.style.width = '100%';
+    }
     const data = new FormData(form);
     try {
       const res = await fetch('/generador', { method: 'POST', body: data });
       const json = await res.json();
       displayResults(json);
-      progress.textContent = '';
     } catch (err) {
-      progress.textContent = 'Error al generar';
+      console.error(err);
+    }
+    if (progressContainer && progressBar) {
+      progressBar.style.width = '0%';
+      progressContainer.style.display = 'none';
     }
   });
 }

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -117,18 +117,7 @@
         </div>
       </div>
 
-      <div id="results">
-        {% if metrics %}
-        <h4 class="mt-4">Resultados</h4>
-        <p>Agentes estimados: {{ metrics.total_agents }}</p>
-        <p>Cobertura: {{ '%.1f'|format(metrics.coverage_percentage) }}%</p>
-        <img src="{{ demand_url }}" class="img-fluid" alt="demand">
-        <img src="{{ image_url }}" class="img-fluid" alt="schedule">
-        {% if download %}
-        <p class="mt-2"><a class="btn btn-success" href="{{ url_for('download') }}">Descargar Excel</a></p>
-        {% endif %}
-        {% endif %}
-      </div>
+      <div id="results"></div>
     </section>
   </div>
 </form>


### PR DESCRIPTION
## Summary
- pass generator form options into scheduler
- refactor scheduler functions to accept configuration dictionaries
- remove server-side rendering of results
- show progress using existing progress bar

## Testing
- `python -m py_compile website/app.py website/scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_6884363afd4c832780db82252cd25ac1