### PR TITLE
Add error handling for optimizer

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -87,7 +87,12 @@ def generador():
             except Exception:
                 flash('Plantilla JEAN inválida')
 
-        result = scheduler.run_complete_optimization(excel, config=cfg)
+        try:
+            result = scheduler.run_complete_optimization(excel, config=cfg)
+        except Exception as e:
+            code = 400 if isinstance(e, ValueError) else 500
+            return {"error": str(e)}, code
+
         result["download_url"] = url_for("download_excel") if session.get("last_excel_result") else None
         return result
 

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -92,10 +92,23 @@ if (form) {
     const data = new FormData(form);
     try {
       const res = await fetch('/generador', { method: 'POST', body: data });
-      const json = await res.json();
+      let json;
+      try {
+        json = await res.json();
+      } catch (err) {
+        console.error('JSON parse error:', err);
+        alert('Error: ' + err);
+        return;
+      }
+      if (!res.ok) {
+        console.error('Server error:', json);
+        alert(json.error || 'Error');
+        return;
+      }
       displayResults(json);
     } catch (err) {
       console.error(err);
+      alert('Error: ' + err);
     }
     if (progressContainer && progressBar) {
       progressBar.style.width = '0%';


### PR DESCRIPTION
## Summary
- handle exceptions when running the optimizer in the Flask route
- report server/JSON errors from the generator form submission

## Testing
- `python -m py_compile website/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884489688c0832785c1d02246d97360