### PR TITLE
Fix HTML responses to JSON requests

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, url_for, session, flash, send_file
+from flask import Flask, render_template, request, redirect, url_for, session, flash, send_file, jsonify
 from functools import wraps
 from . import scheduler
 import io
@@ -15,6 +15,8 @@ def login_required(f):
     @wraps(f)
     def wrapped(*args, **kwargs):
         if not session.get('user'):
+            if 'application/json' in request.headers.get('Accept', ''):
+                return jsonify({'error': 'Unauthorized'}), 401
             return redirect(url_for('login'))
         return f(*args, **kwargs)
     return wrapped

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -91,7 +91,11 @@ if (form) {
     }
     const data = new FormData(form);
     try {
-      const res = await fetch('/generador', { method: 'POST', body: data });
+      const res = await fetch('/generador', {
+        method: 'POST',
+        body: data,
+        headers: { 'Accept': 'application/json' }
+      });
       let json;
       try {
         json = await res.json();


### PR DESCRIPTION
## Summary
- return 401 JSON from `login_required` when request expects JSON
- send `Accept: application/json` when submitting schedule form

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68844b6cfd6c8327ad15e2b2056b67af