### PR TITLE
Fix Matplotlib backend for server

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -11,6 +11,8 @@ import base64
 
 import numpy as np
 import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Use a non-GUI backend for server-side generation
 import matplotlib.pyplot as plt
 import seaborn as sns
 import psutil


### PR DESCRIPTION
## Summary
- switch matplotlib to the non-interactive Agg backend when generating plots in the Flask app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68844f71f7c48327890e3ec176f50ccf