### PR TITLE
Ensure loading spinner always clears

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -185,13 +185,19 @@ document.addEventListener('DOMContentLoaded', function() {
       
       const data = await response.json();
       console.log('📊 Datos recibidos exitosamente');
-      
-      displayResults(data);
-      
+
+      try {
+        displayResults(data);
+      } catch (err) {
+        console.error('❌ Error mostrando resultados:', err);
+        showError('Error: ' + err.message);
+      } finally {
+        showLoading(false);
+      }
+
     } catch (error) {
       console.error('❌ Error:', error);
       showError('Error: ' + error.message);
-    } finally {
       showLoading(false);
     }
   });


### PR DESCRIPTION
## Summary
- handle exceptions from `displayResults()` with its own `try/finally`

## Testing
- `pip install flask pandas numpy matplotlib seaborn openpyxl pulp psutil`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688588d292b08327bd2c86d7a5b08ec5