### PR TITLE
Handle loaded DOM

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -107,7 +107,7 @@ function showLoading(show) {
 }
 
 /* Event bindings - Wait for DOM to load */
-document.addEventListener('DOMContentLoaded', function() {
+function initGenerator() {
   console.log('🚀 Inicializando Generador de Horarios...');
   
   // Verificar que todos los elementos existen
@@ -197,4 +197,10 @@ document.addEventListener('DOMContentLoaded', function() {
   });
   
   console.log('✅ Generador de Horarios inicializado correctamente');
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initGenerator);
+} else {
+  initGenerator();
+}


### PR DESCRIPTION
## Summary
- wrap schedule generator initialization in `initGenerator`
- run `initGenerator` immediately when the DOM is already loaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688588d703988327b31f52d98b167608