### PR TITLE
Use env SECRET_KEY for session

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ This project creates optimized work schedules using Flask.
 
    The list includes the `pulp` package used for solving the optimization problem.
 
-2. Launch the Flask application:
+2. Set the `SECRET_KEY` environment variable used to sign Flask sessions:
+   ```bash
+   export SECRET_KEY="replace-me"
+   ```
+   If this variable is omitted the application falls back to an insecure default and prints a warning.
+
+3. Launch the Flask application:
    ```bash
    flask --app website.app run
    ```
@@ -20,8 +26,8 @@ This project creates optimized work schedules using Flask.
    When prompted on /generador upload the demand Excel file.
 
 
-3. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
-4. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
+4. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
+5. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
 
 ## Excel Input
 

--- a/website/app.py
+++ b/website/app.py
@@ -4,9 +4,15 @@ from . import scheduler
 import io
 import json
 import base64
+import os
+import warnings
 
 app = Flask(__name__)
-app.secret_key = "change-me"
+secret = os.getenv("SECRET_KEY")
+if not secret:
+    warnings.warn("SECRET_KEY environment variable not set, using insecure default")
+    secret = "change-me"
+app.secret_key = secret
 
 users = {}
 


### PR DESCRIPTION
## Summary
- read SECRET_KEY from the environment in `website/app.py`
- warn and fall back to a default when the variable is missing
- document SECRET_KEY usage in README

## Testing
- `pytest -q`
- `python -m py_compile website/app.py`
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_688588daf6f883278bff9202968b5ad1