### PR TITLE
Allow configuring frontend request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ This project creates optimized work schedules using Flask.
    When prompted on /generador upload the demand Excel file.
 
 
-4. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
-5. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
+4. The generator request times out after **120 s** by default. To use a different value set the `data-timeout` attribute (milliseconds) on the `<form id="genForm">` element in `generador.html`.
+5. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
+6. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
 
 ## Excel Input
 

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -151,6 +151,10 @@ function initGenerator() {
     ptCheckbox.addEventListener('change', togglePTOptions);
   }
 
+  // Timeout configurado via data-timeout o valor por defecto (120s)
+  const DEFAULT_REQUEST_TIMEOUT_MS = 120000;
+  const requestTimeout = parseInt(form.dataset.timeout || DEFAULT_REQUEST_TIMEOUT_MS, 10);
+
   // Agregar evento al formulario
   form.addEventListener('submit', async function(ev) {
     ev.preventDefault();
@@ -182,7 +186,7 @@ function initGenerator() {
           headers: { 'Accept': 'application/json' }
         }),
         new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Timeout')), 30000)
+          setTimeout(() => reject(new Error('Timeout')), requestTimeout)
         )
       ]);
       

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -7,7 +7,7 @@
   .tab-pane img{max-width:100%;height:auto;}
 </style>
 <h2 class="mb-4">Generador de Horarios</h2>
-<form method="post" enctype="multipart/form-data" id="genForm">
+<form method="post" enctype="multipart/form-data" id="genForm" data-timeout="120000">
   <div class="row">
     <aside class="col-md-3" id="sidebar">
       <div class="mb-3">


### PR DESCRIPTION
## Summary
- make frontend fetch timeout configurable via `data-timeout`
- default to 120s in template
- document new option in README

## Testing
- `pip install -r requirements.txt` *(fails: `pkgutil` does not provide `ImpImporter`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859337b2f08327bee53a0ef5c96cff