### PR TITLE
Increase scheduler timeout and add diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project creates optimized work schedules using Flask.
    When prompted on /generador upload the demand Excel file.
 
 
-4. The generator request times out after **120 s** by default. To use a different value set the `data-timeout` attribute (milliseconds) on the `<form id="genForm">` element in `generador.html`.
+4. The generator request times out after **240 s** by default. To use a different value set the `data-timeout` attribute (milliseconds) on the `<form id="genForm">` element in `generador.html`.
 5. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
 6. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
 

--- a/website/app.py
+++ b/website/app.py
@@ -141,6 +141,17 @@ def generador():
                 print(f"✅ [DEBUG] Scheduler completado exitosamente")
                 print(f"✅ [DEBUG] Tipo de resultado: {type(result)}")
                 print(f"✅ [DEBUG] Keys en resultado: {list(result.keys()) if isinstance(result, dict) else 'No es dict'}")
+                print("📊 [DEBUG] Verificando librerías...")
+                try:
+                    import pulp
+                    print(f"✅ PuLP disponible: {pulp.__version__}")
+                except Exception:
+                    print("❌ PuLP no disponible")
+                try:
+                    import numpy as np
+                    print(f"✅ NumPy: {np.__version__}")
+                except Exception:
+                    print("❌ NumPy no disponible")
             except Exception as e:
                 print(f"❌ [ERROR] EXCEPCIÓN EN SCHEDULER: {str(e)}")
                 import traceback

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -151,8 +151,8 @@ function initGenerator() {
     ptCheckbox.addEventListener('change', togglePTOptions);
   }
 
-  // Timeout configurado via data-timeout o valor por defecto (120s)
-  const DEFAULT_REQUEST_TIMEOUT_MS = 120000;
+  // Timeout configurado via data-timeout o valor por defecto (240s)
+  const DEFAULT_REQUEST_TIMEOUT_MS = 240000;
   const requestTimeout = parseInt(form.dataset.timeout || DEFAULT_REQUEST_TIMEOUT_MS, 10);
 
   // Agregar evento al formulario

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -7,7 +7,7 @@
   .tab-pane img{max-width:100%;height:auto;}
 </style>
 <h2 class="mb-4">Generador de Horarios</h2>
-<form method="post" enctype="multipart/form-data" id="genForm" data-timeout="120000">
+<form method="post" enctype="multipart/form-data" id="genForm" data-timeout="240000">
   <div class="row">
     <aside class="col-md-3" id="sidebar">
       <div class="mb-3">


### PR DESCRIPTION
## Summary
- use a 4‑minute request timeout in `generador.html` and matching JS constant
- document new timeout in README
- log PuLP and NumPy availability after calling the optimizer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688595b9e0c48327ad4aa360cc333fa9