### PR TITLE
feat: rebuild base template with Bootstrap

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,16 +1,54 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ title or 'Horarios' }}</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
-<body class="container py-4">
-  {% with msgs = get_flashed_messages() %}
-  {% if msgs %}
-    <div class="alert alert-info">{{ msgs[0] }}</div>
-  {% endif %}
-  {% endwith %}
-  {% block content %}{% endblock %}
+<body style="font-family: 'Inter', sans-serif;">
+  <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Schedules</a>
+      <div class="d-flex align-items-center">
+        <button class="btn btn-outline-secondary me-2" id="themeToggle"><i class="bi bi-moon"></i></button>
+        <img src="https://via.placeholder.com/32" class="rounded-circle" alt="avatar">
+      </div>
+    </div>
+  </nav>
+  <div class="d-flex">
+    <aside class="d-flex flex-column flex-shrink-0 p-3 bg-light" style="width: 4.5rem; margin-top: 56px;">
+      <ul class="nav nav-pills nav-flush flex-column mb-auto text-center">
+        <li class="nav-item">
+          <a href="{{ url_for('generador') }}" class="nav-link py-3" title="Generador">
+            <i class="bi bi-pencil-square"></i>
+            <span class="d-none d-sm-inline"> Generador</span>
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link py-3" title="Resultados">
+            <i class="bi bi-bar-chart"></i>
+            <span class="d-none d-sm-inline"> Resultados</span>
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link py-3" title="Configuración">
+            <i class="bi bi-gear"></i>
+            <span class="d-none d-sm-inline"> Configuración</span>
+          </a>
+        </li>
+      </ul>
+    </aside>
+    <main class="flex-grow-1 p-4" style="margin-top:56px;">
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace base layout with Bootstrap 5 structure
- add fixed navbar, sidebar navigation, and theme toggle

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68956bf495c883279a5ba12b4698b84c