### PR TITLE
Add custom styling and dark theme support

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,0 +1,65 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap');
+
+/* Global styles */
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: #f8f9fa;
+}
+
+[data-bs-theme="dark"] {
+  background-color: #121212;
+  color: #f8f9fa;
+}
+
+/* Component customizations */
+.btn-primary {
+  background-image: linear-gradient(45deg, #4e73df, #1cc88a);
+  border: none;
+}
+
+.btn-primary:hover {
+  background-image: linear-gradient(45deg, #1cc88a, #4e73df);
+}
+
+.card {
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.list-group-item.active {
+  background-color: #4e73df;
+  border-color: #4e73df;
+}
+
+.toast {
+  border-radius: 0.5rem;
+}
+
+/* Dark mode adjustments */
+[data-bs-theme="dark"] .card {
+  background-color: #1e1e1e;
+  color: #f8f9fa;
+}
+
+[data-bs-theme="dark"] .list-group-item.active {
+  background-color: #1cc88a;
+  border-color: #1cc88a;
+}
+
+[data-bs-theme="dark"] .toast {
+  background-color: #343a40;
+  color: #f8f9fa;
+}
+
+/* Spinner toggle for Generar button */
+.btn-primary .spinner-border {
+  display: none;
+}
+
+.btn-loading .spinner-border {
+  display: inline-block;
+}
+
+.btn-loading .btn-text {
+  display: none;
+}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>{{ title or 'Horarios' }}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
 <body class="container py-4">
   {% with msgs = get_flashed_messages() %}


### PR DESCRIPTION
## Summary
- Add `custom.css` with Inter font, light/dark themes, component styles, and spinner helpers
- Link new stylesheet in base template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68956bfb4578832785f5d63d9e3d561b