### PR TITLE
Add theme toggle, spinner and timeout toast

### DIFF
--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -1,0 +1,67 @@
+/* global bootstrap */
+function initApp() {
+  // Initialize Bootstrap toasts
+  document.querySelectorAll('.toast').forEach(el => bootstrap.Toast.getOrCreateInstance(el));
+
+  // Theme toggle between light and dark
+  const toggle = document.getElementById('themeToggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const root = document.documentElement;
+      const current = root.getAttribute('data-bs-theme') === 'dark' ? 'dark' : 'light';
+      root.setAttribute('data-bs-theme', current === 'light' ? 'dark' : 'light');
+    });
+  }
+
+  // Handle submit button spinner and timeout toast
+  const form = document.getElementById('genForm');
+  const btn = form ? form.querySelector('button[type="submit"]') : null;
+  let timeoutId = null;
+
+  if (btn && !btn.querySelector('.btn-text')) {
+    const textSpan = document.createElement('span');
+    textSpan.className = 'btn-text';
+    textSpan.textContent = btn.textContent.trim();
+    const spinner = document.createElement('span');
+    spinner.className = 'spinner-border spinner-border-sm d-none';
+    spinner.setAttribute('role', 'status');
+    spinner.setAttribute('aria-hidden', 'true');
+    btn.textContent = '';
+    btn.append(textSpan, spinner);
+  }
+
+  document.addEventListener('generator:loading', e => {
+    if (!btn) return;
+    const textSpan = btn.querySelector('.btn-text');
+    const spinner = btn.querySelector('.spinner-border');
+
+    if (e.detail) {
+      if (textSpan) textSpan.classList.add('d-none');
+      if (spinner) spinner.classList.remove('d-none');
+      btn.disabled = true;
+
+      const toastEl = document.getElementById('timeoutToast');
+      if (toastEl) {
+        const delay = parseInt(toastEl.dataset.timeout || '8000', 10);
+        timeoutId = setTimeout(() => {
+          const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
+          toast.show();
+        }, delay);
+      }
+    } else {
+      if (textSpan) textSpan.classList.remove('d-none');
+      if (spinner) spinner.classList.add('d-none');
+      btn.disabled = false;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    }
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initApp);
+} else {
+  initApp();
+}

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -88,8 +88,7 @@ function showError(message) {
 function showLoading(show) {
   const progressContainer = document.getElementById('progress');
   const progressBar = document.getElementById('progressBar');
-  const generateBtn = document.querySelector('button[type="submit"]');
-  
+
   if (progressContainer && progressBar) {
     if (show) {
       progressContainer.style.display = 'block';
@@ -99,11 +98,7 @@ function showLoading(show) {
       progressContainer.style.display = 'none';
     }
   }
-  
-  if (generateBtn) {
-    generateBtn.disabled = show;
-    generateBtn.textContent = show ? 'Procesando...' : 'Generar';
-  }
+  document.dispatchEvent(new CustomEvent('generator:loading', { detail: show }));
 }
 
 /* Event bindings - Wait for DOM to load */

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,16 +1,19 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
   <meta charset="utf-8">
   <title>{{ title or 'Horarios' }}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body class="container py-4">
+  <button id="themeToggle" class="btn btn-secondary position-fixed top-0 end-0 m-3">🌓</button>
   {% with msgs = get_flashed_messages() %}
   {% if msgs %}
     <div class="alert alert-info">{{ msgs[0] }}</div>
   {% endif %}
   {% endwith %}
   {% block content %}{% endblock %}
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </body>
 </html>

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -123,5 +123,14 @@
     </section>
   </div>
 </form>
+<div class="position-fixed bottom-0 end-0 p-3" style="z-index:11">
+  <div id="timeoutToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-timeout="8000">
+    <div class="toast-header">
+      <strong class="me-auto">Tiempo de espera</strong>
+      <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+    <div class="toast-body">El servidor está tardando más de lo esperado...</div>
+  </div>
+</div>
 <script src="{{ url_for('static', filename='js/generador.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add global app.js to manage theme switching, generator button spinner and timeout toast
- Load Bootstrap bundle and theme toggle button in base template
- Dispatch generator loading events for spinner control

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68956bfcbbdc83279c104b1afc3d1a67