### PR TITLE
Add custom styling and interactive UI elements

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,0 +1,38 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap');
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: #f8f9fa;
+}
+
+html[data-bs-theme="dark"] body {
+  background-color: #212529;
+  color: #f8f9fa;
+}
+
+.btn-primary {
+  background-image: linear-gradient(45deg, #0d6efd, #6610f2);
+  border: none;
+}
+
+.btn-primary:hover {
+  background-image: linear-gradient(45deg, #0b5ed7, #5a0ecf);
+}
+
+.card {
+  border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.05);
+}
+
+html[data-bs-theme="dark"] .card {
+  background-color: #343a40;
+}
+
+.toast {
+  border-radius: 0.5rem;
+}
+
+.list-group-item.active {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+}

--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -2,14 +2,47 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('generatorForm');
   const progress = document.getElementById('progressContainer');
   const toastEl = document.getElementById('timeoutToast');
+  const themeToggle = document.getElementById('themeToggle');
+  const htmlEl = document.documentElement;
   let toast;
 
   if (toastEl) {
     toast = new bootstrap.Toast(toastEl);
   }
 
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const current = htmlEl.getAttribute('data-bs-theme') || 'light';
+      const next = current === 'light' ? 'dark' : 'light';
+      htmlEl.setAttribute('data-bs-theme', next);
+      const icon = themeToggle.querySelector('i');
+      if (icon) {
+        icon.classList.toggle('bi-moon', next === 'light');
+        icon.classList.toggle('bi-sun', next === 'dark');
+      }
+    });
+  }
+
   if (form) {
     form.addEventListener('submit', () => {
+      const btn = form.querySelector('button[type="submit"]');
+      const spinner = btn ? btn.querySelector('.spinner-border') : null;
+      const btnText = btn ? btn.querySelector('.btn-text') : null;
+      const btnIcon = btn ? btn.querySelector('.bi') : null;
+
+      if (btn) {
+        btn.disabled = true;
+      }
+      if (btnText) {
+        btnText.classList.add('d-none');
+      }
+      if (btnIcon) {
+        btnIcon.classList.add('d-none');
+      }
+      if (spinner) {
+        spinner.classList.remove('d-none');
+      }
+
       if (progress) {
         progress.classList.remove('d-none');
       }
@@ -20,4 +53,3 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
-

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -11,7 +11,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
-<body style="font-family: 'Inter', sans-serif;">
+<body>
   <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Schedules</a>
@@ -22,7 +22,7 @@
     </div>
   </nav>
   <div class="d-flex">
-    <aside class="d-flex flex-column flex-shrink-0 p-3 bg-light" style="width: 4.5rem; margin-top: 56px;">
+    <aside class="d-flex flex-column flex-shrink-0 p-3 bg-body-tertiary" style="width: 4.5rem; margin-top: 56px;">
       <ul class="nav nav-pills nav-flush flex-column mb-auto text-center">
         <li class="nav-item">
           <a href="{{ url_for('generador') }}" class="nav-link py-3" title="Generador">

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -25,8 +25,10 @@
           <option>Aprendizaje Adaptativo</option>
         </select>
       </div>
-      <button class="btn btn-primary" type="submit">
-        <i class="bi bi-play-fill"></i> Generar
+      <button class="btn btn-primary d-flex align-items-center gap-2" type="submit" id="generateBtn">
+        <i class="bi bi-play-fill"></i>
+        <span class="btn-text">Generar</span>
+        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
       </button>
     </form>
   </div>
@@ -36,7 +38,7 @@
   <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
 </div>
 
-<div class="toast align-items-center text-bg-warning border-0" id="timeoutToast" role="alert" aria-live="assertive" aria-atomic="true">
+<div class="toast align-items-center text-bg-warning border-0 position-fixed bottom-0 end-0 m-3" id="timeoutToast" role="alert" aria-live="assertive" aria-atomic="true">
   <div class="d-flex">
     <div class="toast-body">
       La generación está tardando más de lo esperado.
@@ -44,7 +46,4 @@
     <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
   </div>
 </div>
-
-<script src="{{ url_for('static', filename='js/app.js') }}"></script>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- Introduce custom.css with Inter font, gradient buttons, card shadows, and dark mode styles
- Enhance app.js to toggle themes, show button spinner, progress bar and timeout toast
- Update base and generador templates to hook new styles and interactive elements

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68956b3a07f8832793983e5420551c5d