### PR TITLE
feat: modernize dashboard UI

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -10,29 +10,46 @@ html[data-bs-theme="dark"] body {
   color: #f8f9fa;
 }
 
-.btn-primary {
-  background-image: linear-gradient(45deg, #0d6efd, #6610f2);
-  border: none;
-}
-
-.btn-primary:hover {
-  background-image: linear-gradient(45deg, #0b5ed7, #5a0ecf);
-}
-
 .card {
-  border-radius: 0.5rem;
-  box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.05);
+  border-radius: 1rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(0,0,0,0.05);
 }
 
 html[data-bs-theme="dark"] .card {
   background-color: #343a40;
 }
 
-.toast {
-  border-radius: 0.5rem;
+.btn-primary {
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  border: none;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(135deg, #4f46e5, #4338ca);
+}
+
+.sidebar .list-group-item {
+  border: none;
+}
+
+.sidebar .list-group-item:hover {
+  background-color: #e9ecef;
+}
+
+html[data-bs-theme="dark"] .sidebar {
+  background-color: #2b3035;
+}
+
+html[data-bs-theme="dark"] .sidebar .list-group-item:hover {
+  background-color: #343a40;
 }
 
 .list-group-item.active {
-  background-color: #0d6efd;
-  border-color: #0d6efd;
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  border: none;
+  color: #fff;
+}
+
+.toast {
+  border-radius: 0.5rem;
 }

--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const toastEl = document.getElementById('timeoutToast');
   const themeToggle = document.getElementById('themeToggle');
   const htmlEl = document.documentElement;
+  const TIMEOUT_MS = 30000;
   let toast;
 
   if (toastEl) {
@@ -25,30 +26,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (form) {
     form.addEventListener('submit', () => {
-      const btn = form.querySelector('button[type="submit"]');
-      const spinner = btn ? btn.querySelector('.spinner-border') : null;
-      const btnText = btn ? btn.querySelector('.btn-text') : null;
-      const btnIcon = btn ? btn.querySelector('.bi') : null;
+      const btn = document.getElementById('generateBtn');
+      const spinner = btn.querySelector('.spinner-border');
+      const btnText = btn.querySelector('.btn-text');
+      const btnIcon = btn.querySelector('.bi');
 
-      if (btn) {
-        btn.disabled = true;
-      }
-      if (btnText) {
-        btnText.classList.add('d-none');
-      }
-      if (btnIcon) {
-        btnIcon.classList.add('d-none');
-      }
-      if (spinner) {
-        spinner.classList.remove('d-none');
-      }
+      btn.disabled = true;
+      btnText.classList.add('d-none');
+      btnIcon.classList.add('d-none');
+      spinner.classList.remove('d-none');
 
       if (progress) {
         progress.classList.remove('d-none');
       }
 
       if (toast) {
-        setTimeout(() => toast.show(), 30000);
+        setTimeout(() => toast.show(), TIMEOUT_MS);
       }
     });
   }

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -14,35 +14,41 @@
 <body>
   <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
     <div class="container-fluid">
-      <a class="navbar-brand" href="#">Schedules</a>
-      <div class="d-flex align-items-center">
-        <button class="btn btn-outline-secondary me-2" id="themeToggle"><i class="bi bi-moon"></i></button>
-        <img src="https://via.placeholder.com/32" class="rounded-circle" alt="avatar">
+      <a class="navbar-brand d-flex align-items-center" href="/">
+        <i class="bi bi-calendar-check me-2"></i>
+        <span class="fs-5 fw-semibold">Schedules</span>
+      </a>
+      <div class="d-flex align-items-center ms-auto">
+        <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema">
+          <i class="bi bi-moon"></i>
+        </button>
+        <div class="dropdown">
+          <button class="btn btn-link p-0 text-decoration-none dropdown-toggle d-flex align-items-center" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Usuario">
+            <img src="https://via.placeholder.com/32" class="rounded-circle me-2" alt="avatar">
+            <span>Jean</span>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li><a class="dropdown-item" href="#">Perfil</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#">Salir</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </nav>
   <div class="d-flex">
-    <aside class="d-flex flex-column flex-shrink-0 p-3 bg-body-tertiary" style="width: 4.5rem; margin-top: 56px;">
-      <ul class="nav nav-pills nav-flush flex-column mb-auto text-center">
-        <li class="nav-item">
-          <a href="{{ url_for('generador') }}" class="nav-link py-3" title="Generador">
-            <i class="bi bi-pencil-square"></i>
-            <span class="d-none d-sm-inline"> Generador</span>
-          </a>
-        </li>
-        <li>
-          <a href="#" class="nav-link py-3" title="Resultados">
-            <i class="bi bi-bar-chart"></i>
-            <span class="d-none d-sm-inline"> Resultados</span>
-          </a>
-        </li>
-        <li>
-          <a href="#" class="nav-link py-3" title="Configuración">
-            <i class="bi bi-gear"></i>
-            <span class="d-none d-sm-inline"> Configuración</span>
-          </a>
-        </li>
-      </ul>
+    <aside class="sidebar d-flex flex-column flex-shrink-0 p-3 bg-light" style="width: 240px; margin-top:56px;">
+      <div class="list-group list-group-flush">
+        <a href="{{ url_for('generador') }}" class="list-group-item list-group-item-action d-flex align-items-center {% if request.endpoint == 'generador' %}active{% endif %}">
+          <i class="bi bi-sliders me-2"></i> Generador
+        </a>
+        <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
+          <i class="bi bi-graph-up me-2"></i> Resultados
+        </a>
+        <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
+          <i class="bi bi-gear me-2"></i> Configuración
+        </a>
+      </div>
     </aside>
     <main class="flex-grow-1 p-4" style="margin-top:56px;">
       {% block content %}{% endblock %}

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -1,32 +1,37 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="card">
+<div class="card mx-auto" style="max-width: 700px;">
   <div class="card-body">
-    <form id="generatorForm" method="post" enctype="multipart/form-data">
-      <div class="mb-3">
-        <label for="excel" class="form-label">Archivo Excel</label>
-        <input type="file" class="form-control" id="excel" name="excel" accept=".xlsx" required>
+    <h4 class="card-title text-center fw-bold mb-4">Generador de Horarios</h4>
+    <form id="generatorForm" method="post" enctype="multipart/form-data" aria-label="Generador de horarios">
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <label for="excel" class="form-label">Archivo Excel</label>
+          <input type="file" class="form-control" id="excel" name="excel" accept=".xlsx" required>
+        </div>
+        <div class="col-md-6">
+          <div class="form-floating">
+            <select class="form-select" id="profile" name="profile" aria-label="Perfil de optimización">
+              <option>Equilibrado (Recomendado)</option>
+              <option>Conservador</option>
+              <option>Agresivo</option>
+              <option>Máxima Cobertura</option>
+              <option>Mínimo Costo</option>
+              <option>100% Cobertura Eficiente</option>
+              <option>100% Cobertura Total</option>
+              <option>Cobertura Perfecta</option>
+              <option>100% Exacto</option>
+              <option>JEAN</option>
+              <option>JEAN Personalizado</option>
+              <option>Personalizado</option>
+              <option>Aprendizaje Adaptativo</option>
+            </select>
+            <label for="profile">Perfil de optimización</label>
+          </div>
+        </div>
       </div>
-      <div class="mb-3">
-        <label for="profile" class="form-label">Perfil de optimización</label>
-        <select class="form-select" id="profile" name="profile">
-          <option>Equilibrado (Recomendado)</option>
-          <option>Conservador</option>
-          <option>Agresivo</option>
-          <option>Máxima Cobertura</option>
-          <option>Mínimo Costo</option>
-          <option>100% Cobertura Eficiente</option>
-          <option>100% Cobertura Total</option>
-          <option>Cobertura Perfecta</option>
-          <option>100% Exacto</option>
-          <option>JEAN</option>
-          <option>JEAN Personalizado</option>
-          <option>Personalizado</option>
-          <option>Aprendizaje Adaptativo</option>
-        </select>
-      </div>
-      <button class="btn btn-primary d-flex align-items-center gap-2" type="submit" id="generateBtn">
-        <i class="bi bi-play-fill"></i>
+      <button class="btn btn-primary d-inline-flex align-items-center gap-2" type="submit" id="generateBtn" aria-label="Generar">
+        <i class="bi bi-play-circle"></i>
         <span class="btn-text">Generar</span>
         <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
       </button>
@@ -34,11 +39,11 @@
   </div>
 </div>
 
-<div class="progress d-none mt-3" id="progressContainer">
-  <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
+<div class="progress d-none mt-3" id="progressContainer" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+  <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
 </div>
 
-<div class="toast align-items-center text-bg-warning border-0 position-fixed bottom-0 end-0 m-3" id="timeoutToast" role="alert" aria-live="assertive" aria-atomic="true">
+<div class="toast text-bg-warning border-0 position-fixed bottom-0 end-0 m-3" id="timeoutToast" role="alert" aria-live="assertive" aria-atomic="true">
   <div class="d-flex">
     <div class="toast-body">
       La generación está tardando más de lo esperado.


### PR DESCRIPTION
## Summary
- restyle navbar with logo, theme toggle, and dropdown avatar
- convert sidebar to list-group dashboard menu
- redesign generator view inside card with progress bar and toast
- add modern gradient styling and JS theme handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68957503634c832788a51f7995f3317b