### PR TITLE
Enhance UI polish and theme persistence

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -10,6 +10,10 @@ html[data-bs-theme="dark"] body {
   color: #f8f9fa;
 }
 
+html {
+  transition: color 0.3s ease, background-color 0.3s ease;
+}
+
 .card {
   border-radius: 1rem;
   box-shadow: 0 0.75rem 1.5rem rgba(0,0,0,0.05);

--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -1,48 +1,48 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const form = document.getElementById('generatorForm');
-  const progress = document.getElementById('progressContainer');
-  const toastEl = document.getElementById('timeoutToast');
-  const themeToggle = document.getElementById('themeToggle');
   const htmlEl = document.documentElement;
-  const TIMEOUT_MS = 30000;
-  let toast;
-
-  if (toastEl) {
-    toast = new bootstrap.Toast(toastEl);
-  }
+  const themeToggle = document.getElementById('themeToggle');
+  const storedTheme = localStorage.getItem('theme') || 'light';
+  htmlEl.setAttribute('data-bs-theme', storedTheme);
 
   if (themeToggle) {
+    const icon = themeToggle.querySelector('i');
+    if (icon) {
+      icon.classList.toggle('bi-moon', storedTheme === 'light');
+      icon.classList.toggle('bi-sun', storedTheme === 'dark');
+    }
     themeToggle.addEventListener('click', () => {
-      const current = htmlEl.getAttribute('data-bs-theme') || 'light';
+      const current = htmlEl.getAttribute('data-bs-theme') === 'dark' ? 'dark' : 'light';
       const next = current === 'light' ? 'dark' : 'light';
       htmlEl.setAttribute('data-bs-theme', next);
-      const icon = themeToggle.querySelector('i');
       if (icon) {
         icon.classList.toggle('bi-moon', next === 'light');
         icon.classList.toggle('bi-sun', next === 'dark');
       }
+      localStorage.setItem('theme', next);
     });
   }
 
+  const form = document.getElementById('genForm');
   if (form) {
     form.addEventListener('submit', () => {
-      const btn = document.getElementById('generateBtn');
-      const spinner = btn.querySelector('.spinner-border');
-      const btnText = btn.querySelector('.btn-text');
-      const btnIcon = btn.querySelector('.bi');
-
-      btn.disabled = true;
-      btnText.classList.add('d-none');
-      btnIcon.classList.add('d-none');
-      spinner.classList.remove('d-none');
-
+      const btn = document.getElementById('btnGenerar');
+      const spinner = document.getElementById('spinner');
+      const progress = document.getElementById('progressContainer');
+      if (btn && spinner) {
+        btn.disabled = true;
+        spinner.classList.remove('d-none');
+      }
       if (progress) {
         progress.classList.remove('d-none');
       }
-
-      if (toast) {
-        setTimeout(() => toast.show(), TIMEOUT_MS);
-      }
+      setTimeout(() => {
+        const toastEl = document.getElementById('warningToast');
+        if (toastEl) {
+          const toast = new bootstrap.Toast(toastEl);
+          toast.show();
+        }
+      }, 240000);
     });
   }
 });
+

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -15,22 +15,28 @@
   <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
     <div class="container-fluid">
       <a class="navbar-brand d-flex align-items-center" href="/">
-        <i class="bi bi-calendar-check me-2"></i>
+        <i class="bi bi-calendar-check me-2" aria-hidden="true"></i>
         <span class="fs-5 fw-semibold">Schedules</span>
       </a>
       <div class="d-flex align-items-center ms-auto">
-        <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema">
-          <i class="bi bi-moon"></i>
+        <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
+          <i class="bi bi-moon" aria-hidden="true"></i>
         </button>
         <div class="dropdown">
-          <button class="btn btn-link p-0 text-decoration-none dropdown-toggle d-flex align-items-center" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Usuario">
-            <img src="https://via.placeholder.com/32" class="rounded-circle me-2" alt="avatar">
-            <span>Jean</span>
-          </button>
+          {% set avatar = session.get('avatar_url') %}
+          {% set username = session.get('user', 'Invitado') %}
+          <a href="#" class="d-flex align-items-center text-decoration-none" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {% if avatar %}
+              <img src="{{ avatar }}" class="rounded-circle me-2" alt="avatar" width="32" height="32">
+            {% else %}
+              <i class="bi bi-person-circle fs-4 me-2" aria-hidden="true"></i>
+            {% endif %}
+            <span>{{ username }} ▾</span>
+          </a>
           <ul class="dropdown-menu dropdown-menu-end">
             <li><a class="dropdown-item" href="#">Perfil</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="#">Salir</a></li>
+            <li><a class="dropdown-item" href="{{ url_for('logout') }}">Salir</a></li>
           </ul>
         </div>
       </div>
@@ -39,14 +45,14 @@
   <div class="d-flex">
     <aside class="sidebar d-flex flex-column flex-shrink-0 p-3 bg-light" style="width: 240px; margin-top:56px;">
       <div class="list-group list-group-flush">
-        <a href="{{ url_for('generador') }}" class="list-group-item list-group-item-action d-flex align-items-center {% if request.endpoint == 'generador' %}active{% endif %}">
-          <i class="bi bi-sliders me-2"></i> Generador
+        <a href="{{ url_for('generador') }}" class="list-group-item list-group-item-action d-flex align-items-center {% if request.endpoint == 'generador' %}active bg-primary text-white{% endif %}" {% if request.endpoint == 'generador' %}aria-current="true"{% endif %}>
+          <i class="bi bi-sliders me-2" aria-hidden="true"></i> Generador
         </a>
         <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
-          <i class="bi bi-graph-up me-2"></i> Resultados
+          <i class="bi bi-graph-up me-2" aria-hidden="true"></i> Resultados
         </a>
         <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
-          <i class="bi bi-gear me-2"></i> Configuración
+          <i class="bi bi-gear me-2" aria-hidden="true"></i> Configuración
         </a>
       </div>
     </aside>

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -3,7 +3,7 @@
 <div class="card mx-auto" style="max-width: 700px;">
   <div class="card-body">
     <h4 class="card-title text-center fw-bold mb-4">Generador de Horarios</h4>
-    <form id="generatorForm" method="post" enctype="multipart/form-data" aria-label="Generador de horarios">
+    <form id="genForm" method="post" enctype="multipart/form-data" aria-label="Generador de horarios">
       <div class="row g-3 mb-3">
         <div class="col-md-6">
           <label for="excel" class="form-label">Archivo Excel</label>
@@ -30,10 +30,9 @@
           </div>
         </div>
       </div>
-      <button class="btn btn-primary d-inline-flex align-items-center gap-2" type="submit" id="generateBtn" aria-label="Generar">
-        <i class="bi bi-play-circle"></i>
-        <span class="btn-text">Generar</span>
-        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+      <button type="submit" id="btnGenerar" class="btn btn-primary d-inline-flex align-items-center gap-2">
+        <i class="bi bi-play-circle" aria-hidden="true"></i> <span>Generar</span>
+        <span id="spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
       </button>
     </form>
   </div>
@@ -43,7 +42,7 @@
   <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
 </div>
 
-<div class="toast text-bg-warning border-0 position-fixed bottom-0 end-0 m-3" id="timeoutToast" role="alert" aria-live="assertive" aria-atomic="true">
+<div class="toast text-bg-warning border-0 position-fixed bottom-0 end-0 m-3" id="warningToast" role="alert" aria-live="assertive" aria-atomic="true">
   <div class="d-flex">
     <div class="toast-body">
       La generación está tardando más de lo esperado.


### PR DESCRIPTION
## Summary
- Fix navbar profile dropdown with avatar fallback and right-aligned menu
- Highlight active sidebar links and improve accessibility
- Disable generate button with spinner and toast timeout; persist dark mode via localStorage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68957789a6608327a3f14ffc6edd00ee