### PR TITLE
Render /generador results via HTML template

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -165,7 +165,7 @@ def generador():
             print("📤 [DEBUG] Enviando respuesta al frontend...")
             print(f"📤 [DEBUG] Tamaño de respuesta: {len(str(result))} caracteres")
 
-            return result
+            return render_template('resultados.html', resultado=result)
 
         except Exception as e:
             print(f"\u274C [ERROR] Exception en POST: {str(e)}")


### PR DESCRIPTION
## Summary
- serve optimization results through resultados.html instead of JSON

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957c36db448327b75391fb13575200