### PR TITLE
Relax pulp dependency pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numpy==1.24.3
 matplotlib==3.7.2
 seaborn==0.12.2
 openpyxl==3.1.2
-pulp==2.7.0
+pulp==2.7.*
 psutil==5.9.5


### PR DESCRIPTION
## Summary
- Allow any pulp 2.7 patch release in requirements

## Testing
- `python -m pip install pulp==2.7.*`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896889791c88327a9bc427031706cc5