### PR TITLE
Log PuLP availability during scheduler import

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -25,6 +25,8 @@ try:
 except Exception:
     PULP_AVAILABLE = False
 
+print(f"[OPTIMIZER] PuLP disponible: {PULP_AVAILABLE}")
+
 # Default configuration values used when no override is supplied
 DEFAULT_CONFIG = {
     # Streamlit legacy defaults from ``legacy/app1.py``


### PR DESCRIPTION
## Summary
- Add diagnostic print confirming PuLP availability when scheduler module loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896889b73e48327abdda193152efc64