### PR TITLE
Persist optimization results and add configuration routes

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -1061,6 +1061,30 @@ def generate_shifts_coverage_optimized(
     Logic mirrors ``generate_shifts_coverage_optimized`` in ``legacy/app1.py``
     but omits any Streamlit UI elements.
     """
+    cfg = merge_config(cfg)
+    profile = cfg.get('optimization_profile', 'Equilibrado (Recomendado)')
+    if profile == 'JEAN Personalizado':
+        slot_minutes = int(cfg.get('slot_duration_minutes', 30))
+        start_hours = [h for h in np.arange(0, 24, slot_minutes / 60) if h <= 23.5]
+        patterns = load_shift_patterns(
+            cfg,
+            start_hours=start_hours,
+            break_from_start=cfg.get('break_from_start', DEFAULT_CONFIG['break_from_start']),
+            break_from_end=cfg.get('break_from_end', DEFAULT_CONFIG['break_from_end']),
+            slot_duration_minutes=slot_minutes,
+            demand_matrix=demand_matrix,
+            keep_percentage=cfg.get('keep_percentage', 0.3),
+            peak_bonus=cfg.get('peak_bonus', 1.5),
+            critical_bonus=cfg.get('critical_bonus', 2.0),
+            efficiency_bonus=cfg.get('efficiency_bonus', 1.0),
+            max_patterns=cfg.get('max_patterns')
+        )
+        if not cfg.get('use_ft', True):
+            patterns = {k: v for k, v in patterns.items() if not k.startswith('FT')}
+        if not cfg.get('use_pt', True):
+            patterns = {k: v for k, v in patterns.items() if not k.startswith('PT')}
+        yield patterns
+        return
     selected = 0
     seen = set()
     inner = generate_shifts_coverage_corrected(batch_size=batch_size, cfg=cfg)

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -34,7 +34,7 @@
             <span>{{ username }} ▾</span>
           </a>
           <ul class="dropdown-menu dropdown-menu-end">
-            <li><a class="dropdown-item" href="#">Perfil</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('configuracion') }}">Perfil</a></li>
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" href="{{ url_for('logout') }}">Salir</a></li>
           </ul>
@@ -44,17 +44,17 @@
   </nav>
   <div class="d-flex">
     <aside class="sidebar d-flex flex-column flex-shrink-0 p-3 bg-light" style="width: 240px; margin-top:56px;">
-      <div class="list-group list-group-flush">
-        <a href="{{ url_for('generador') }}" class="list-group-item list-group-item-action d-flex align-items-center {% if request.endpoint == 'generador' %}active bg-primary text-white{% endif %}" {% if request.endpoint == 'generador' %}aria-current="true"{% endif %}>
-          <i class="bi bi-sliders me-2" aria-hidden="true"></i> Generador
-        </a>
-        <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
-          <i class="bi bi-graph-up me-2" aria-hidden="true"></i> Resultados
-        </a>
-        <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
-          <i class="bi bi-gear me-2" aria-hidden="true"></i> Configuración
-        </a>
-      </div>
+        <div class="list-group list-group-flush">
+          <a class="list-group-item list-group-item-action d-flex align-items-center {{ 'active bg-primary text-white' if request.endpoint == 'generador' else '' }}" href="{{ url_for('generador') }}">
+            <i class="bi bi-sliders me-2" aria-hidden="true"></i> Generador
+          </a>
+          <a class="list-group-item list-group-item-action d-flex align-items-center {{ 'active bg-primary text-white' if request.endpoint == 'resultados' else '' }}" href="{{ url_for('resultados') }}">
+            <i class="bi bi-graph-up me-2" aria-hidden="true"></i> Resultados
+          </a>
+          <a class="list-group-item list-group-item-action d-flex align-items-center {{ 'active bg-primary text-white' if request.endpoint == 'configuracion' else '' }}" href="{{ url_for('configuracion') }}">
+            <i class="bi bi-gear me-2" aria-hidden="true"></i> Configuración
+          </a>
+        </div>
     </aside>
     <main class="flex-grow-1 p-4" style="margin-top:56px;">
       {% block content %}{% endblock %}

--- a/website/templates/configuracion.html
+++ b/website/templates/configuracion.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block content %}
+<p>En construcción</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Persist result and configuration in session and add views for resultados, configuracion, and perfil
- Update sidebar and user dropdown; create configuracion template
- Add JEAN Personalizado profile handling in scheduler and verify Excel day parsing

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896a1147f2883278166addf8653bf6c