### PR TITLE
Open temporary JSON result file in text mode

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -169,7 +169,7 @@ def generador():
                     os.remove(session['last_result_file'])
                 except Exception:
                     pass
-            tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.json')
+            tmp = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json', encoding='utf-8')
             json.dump(result, tmp)
             tmp.flush()
             tmp.close()


### PR DESCRIPTION
## Summary
- Open temporary result file in UTF-8 text mode to safely dump JSON

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896a72d77988327a66d8ab6cc01e972