### PR TITLE
feat: login split screen

### DIFF
--- a/website/templates/login.html
+++ b/website/templates/login.html
@@ -1,14 +1,57 @@
-{% extends 'base.html' %}
-{% block content %}
-<h2>Login</h2>
-<form method="post">
-  <div class="mb-3">
-    <input type="text" name="username" placeholder="Usuario" class="form-control" required>
+<!doctype html>
+<html lang="es" data-bs-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body>
+  <div class="container-fluid">
+    <div class="row min-vh-100">
+      <div class="col-md-6 d-none d-md-flex bg-light align-items-center justify-content-center">
+        <div class="text-center">
+          <h1 class="display-4 fw-bold">Schedules</h1>
+          <p class="lead">Organiza tus horarios de manera sencilla</p>
+        </div>
+      </div>
+      <div class="col-md-6 d-flex align-items-center justify-content-center p-4">
+        <div class="w-100" style="max-width: 360px;">
+          {% with messages = get_flashed_messages() %}
+            {% if messages %}
+              {% for message in messages %}
+                <div class="alert alert-info alert-dismissible fade show" role="alert">
+                  {{ message }}
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+              {% endfor %}
+            {% endif %}
+          {% endwith %}
+          <form action="{{ url_for('login') }}" method="post">
+            <h2 class="mb-4 text-center">Iniciar sesi\u00f3n</h2>
+            <div class="mb-3">
+              <input type="text" name="username" placeholder="Usuario" class="form-control" required>
+            </div>
+            <div class="mb-3">
+              <input type="password" name="password" placeholder="Contrase\u00f1a" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Entrar</button>
+          </form>
+          <p class="text-center mt-3 mb-0">
+            <a href="{{ url_for('login') }}" class="text-decoration-none me-2">Login</a>
+            <span class="text-muted">·</span>
+            <a href="{{ url_for('register') }}" class="text-decoration-none ms-2">Registro</a>
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
-  <div class="mb-3">
-    <input type="password" name="password" placeholder="Contrase\u00f1a" class="form-control" required>
-  </div>
-  <button class="btn btn-success">Entrar</button>
-  <a href="{{ url_for('register') }}" class="btn btn-link">Registro</a>
-</form>
-{% endblock %}
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace login template with split-screen layout and branding
- add Inter font and Bootstrap 5.3.3 CDN links
- retain flash message handling and login/register links

## Testing
- `python -m py_compile website/app.py website/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6896ca8bbe188327aedc9da0d0b7aff1