### PR TITLE
Simplify templates to rely on base layout

### DIFF
--- a/website/templates/configuracion.html
+++ b/website/templates/configuracion.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends 'base.html' %}
 {% block content %}
 <p>En construcción</p>
 {% endblock %}

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="container-xxl py-4">
 
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h2 class="mb-0 fw-bold">Generador de Turnos</h2>
@@ -189,8 +188,6 @@
     </div>
 
   </form>
-
-</div>
 
 <script>
 (() => {

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="container-xxl py-4">
 
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h2 class="mb-0 fw-bold">Resultados</h2>
@@ -116,5 +115,4 @@
   <div class="alert alert-warning">No hay resultados para mostrar.</div>
   {% endif %}
 
-</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove extra container wrappers from generator and results templates
- standardize configuration template extend syntax
- verified index and registration templates already use base layout

## Testing
- `pytest -q`
- `python - <<'PY' ... PY` (rendered each page and confirmed `<main>` wrapper)


------
https://chatgpt.com/codex/tasks/task_e_6896ca8fa3788327a5d03e48ad806fee