### PR TITLE
Add dark mode toggle to landing page

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landing</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background-color: #ffffff;
+      color: #000000;
+      transition: background-color 0.3s ease, color 0.3s ease;
+    }
+    body.dark {
+      background-color: #121212;
+      color: #f5f5f5;
+    }
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem;
+      background-color: #f0f0f0;
+    }
+    body.dark nav {
+      background-color: #1e1e1e;
+    }
+    button#themeToggle {
+      padding: 0.5rem 1rem;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <span>Landing Page</span>
+    <button id="themeToggle" type="button">Toggle theme</button>
+  </nav>
+  <main>
+    <h1>Bienvenido</h1>
+    <p>Esta es la página de aterrizaje.</p>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const body = document.body;
+      const toggle = document.getElementById('themeToggle');
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark') {
+        body.classList.add('dark');
+      }
+      toggle.addEventListener('click', () => {
+        const isDark = body.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add navbar toggle to landing page
- implement script to persist theme preference with localStorage
- include basic dark theme styles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896dab930a88327b2f8e04b81bd3789