### PR TITLE
refactor: extract landing page styles to CSS file

### DIFF
--- a/website/static/css/landing.css
+++ b/website/static/css/landing.css
@@ -1,0 +1,26 @@
+:root {
+  --brand: #2d6cdf;
+  --brand-600: #1e56c4;
+  --ink-600: #2b3440;
+  --muted: #8a94a6;
+  --bg-soft: #f7f8fb;
+}
+html,body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif; }
+.btn-brand { background: var(--brand); border-color: var(--brand); }
+.btn-brand:hover { background: var(--brand-600); border-color: var(--brand-600); }
+.text-ink { color: var(--ink-600); }
+.text-muted-adv { color: var(--muted); }
+.bg-soft { background: var(--bg-soft); }
+.hero { background: radial-gradient(1400px 600px at -10% 0%, #e7efff 0%, #fff 50%, #fff 100%); }
+.metric { min-width: 180px; }
+.logo-pill{ opacity:.6; transition:.2s; }
+.logo-pill:hover{ opacity:1; }
+.feature-icon{ width:48px;height:48px;border-radius:12px;background:#eef3ff;color:var(--brand);
+  display:flex;align-items:center;justify-content:center;font-size:22px; }
+.check { color:#16a34a; }
+.shadow-soft{ box-shadow: 0 8px 30px rgba(17, 24, 39, .06); }
+.pricing .card{ border:1px solid #edf1f7; }
+.nav-link:hover { color: var(--brand); }
+.badge-dot{width:10px;height:10px;border-radius:50%;background:#00e0b8;display:inline-block;margin-right:.5rem;}
+.footer-link{ color:#667085; text-decoration:none; }
+.footer-link:hover{ color:#111827; }

--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -17,35 +17,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
-
-  <style>
-    :root {
-      --brand: #2d6cdf;
-      --brand-600: #1e56c4;
-      --ink-600: #2b3440;
-      --muted: #8a94a6;
-      --bg-soft: #f7f8fb;
-    }
-    html,body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif; }
-    .btn-brand { background: var(--brand); border-color: var(--brand); }
-    .btn-brand:hover { background: var(--brand-600); border-color: var(--brand-600); }
-    .text-ink { color: var(--ink-600); }
-    .text-muted-adv { color: var(--muted); }
-    .bg-soft { background: var(--bg-soft); }
-    .hero { background: radial-gradient(1400px 600px at -10% 0%, #e7efff 0%, #fff 50%, #fff 100%); }
-    .metric { min-width: 180px; }
-    .logo-pill{ opacity:.6; transition:.2s; }
-    .logo-pill:hover{ opacity:1; }
-    .feature-icon{ width:48px;height:48px;border-radius:12px;background:#eef3ff;color:var(--brand);
-      display:flex;align-items:center;justify-content:center;font-size:22px; }
-    .check { color:#16a34a; }
-    .shadow-soft{ box-shadow: 0 8px 30px rgba(17, 24, 39, .06); }
-    .pricing .card{ border:1px solid #edf1f7; }
-    .nav-link:hover { color: var(--brand); }
-    .badge-dot{width:10px;height:10px;border-radius:50%;background:#00e0b8;display:inline-block;margin-right:.5rem;}
-    .footer-link{ color:#667085; text-decoration:none; }
-    .footer-link:hover{ color:#111827; }
-  </style>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/landing.css') }}">
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- move inline landing page styles into `static/css/landing.css`
- link `landing.css` from `landing.html`
- confirm no overlap with `static/css/custom.css`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68977d23debc83279bd4088ad8c8568f