### PR TITLE
Render current year in landing footer

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -17,6 +17,7 @@ import json, io
 import os
 import warnings
 import tempfile
+from datetime import datetime
 
 app = Flask(__name__)
 secret = os.getenv("SECRET_KEY")
@@ -53,7 +54,7 @@ def _on(name: str) -> bool:
 
 @app.route('/', methods=['GET'])
 def landing():
-    return render_template('landing.html', title='Schedules')
+    return render_template('landing.html', title='Schedules', year=datetime.now().year)
 
 
 @app.route('/app', methods=['GET'])

--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -396,7 +396,7 @@
 <!-- FOOTER -->
 <footer id="contact" class="py-4 border-top">
   <div class="container-xxl d-flex flex-wrap justify-content-between align-items-center gap-3">
-    <div class="small text-muted-adv">© {{ 2025 }} Schedules. Todos los derechos reservados.</div>
+    <div class="small text-muted-adv">© {{ year }} Schedules. Todos los derechos reservados.</div>
     <div class="d-flex gap-3 small">
       <a class="footer-link" href="#features">Funciones</a>
       <a class="footer-link" href="#pricing">Precios</a>


### PR DESCRIPTION
## Summary
- Pass current year from Flask view to landing template
- Use dynamic `{{ year }}` in footer instead of fixed `2025`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68977d25d8cc8327ac07f7d326c25870