### PR TITLE
Add contact and PayPal payment routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+allowlist.txt
+website/allowlist.txt

--- a/website/templates/checkout.html
+++ b/website/templates/checkout.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Checkout - {{ plan_info.description }}</h1>
+<p>Precio: {{ plan_info.price }} USD</p>
+<div id="paypal-button-container"></div>
+{% endblock %}

--- a/website/templates/contacto.html
+++ b/website/templates/contacto.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Contacto</h1>
+<form method="post">
+  <div class="mb-3">
+    <label for="email" class="form-label">Correo</label>
+    <input type="email" class="form-control" name="email" id="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="intention" class="form-label">¿Qué deseas?</label>
+    <select name="intention" id="intention" class="form-select">
+      <option value="subscription">Suscripción</option>
+      {% for key, plan in PLANS.items() %}
+      <option value="{{ key }}">Pago único - {{ plan.description }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Continuar</button>
+</form>
+{% endblock %}

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Suscripción</h1>
+<p>Completa la suscripción recurrente mediante PayPal.</p>
+<div id="paypal-button-container"></div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add catalog of payment plans and helper utilities for allowlist and admin notifications
- Implement contact form, subscription page, checkout flow and PayPal API stubs
- Store purchaser email on activation or capture and notify administrator

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689781c3b0608327a733ce247a3a46ae