### PR TITLE
Add PayPal contact, subscription, and checkout templates

### DIFF
--- a/website/templates/checkout.html
+++ b/website/templates/checkout.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Pago</h1>
+<div id="paypal-button-container"></div>
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&currency=USD"></script>
+<script>
+  paypal.Buttons({
+    createOrder: function(data, actions) {
+      return actions.order.create({
+        purchase_units: [{
+          amount: { value: '10.00' }
+        }]
+      });
+    },
+    onApprove: function(data, actions) {
+      return actions.order.capture().then(function(details) {
+        alert('Transacción completada por ' + details.payer.name.given_name);
+      });
+    }
+  }).render('#paypal-button-container');
+</script>
+{% endblock %}

--- a/website/templates/contacto.html
+++ b/website/templates/contacto.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Contacto y Cotización</h1>
+<form class="mb-4">
+  <div class="mb-3">
+    <label for="name" class="form-label">Nombre</label>
+    <input type="text" class="form-control" id="name" placeholder="Tu nombre">
+  </div>
+  <div class="mb-3">
+    <label for="email" class="form-label">Correo</label>
+    <input type="email" class="form-control" id="email" placeholder="nombre@ejemplo.com">
+  </div>
+  <div class="mb-3">
+    <label for="message" class="form-label">Mensaje</label>
+    <textarea class="form-control" id="message" rows="4" placeholder="Describe tu proyecto o consulta"></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Enviar</button>
+</form>
+
+<div id="paypal-button-container"></div>
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&currency=USD"></script>
+<script>
+  paypal.Buttons().render('#paypal-button-container');
+</script>
+{% endblock %}

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Suscripción</h1>
+<form class="mb-4">
+  <div class="mb-3">
+    <label for="email" class="form-label">Correo</label>
+    <input type="email" class="form-control" id="email" placeholder="nombre@ejemplo.com">
+  </div>
+</form>
+
+<div id="paypal-button-container"></div>
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&vault=true&intent=subscription"></script>
+<script>
+  paypal.Buttons({
+    createSubscription: function(data, actions) {
+      return actions.subscription.create({ plan_id: 'P-PLAN_ID' });
+    },
+    onApprove: function(data, actions) {
+      alert('Suscripción completada');
+    }
+  }).render('#paypal-button-container');
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `contacto.html` with contact/quote form and PayPal button
- add `subscribe.html` with email capture and PayPal subscription
- add `checkout.html` for one-time payments via PayPal Orders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689781cb3e94832786d52e02e0d851c7