### PR TITLE
Add contact link and subscription CTA to landing navbar

### DIFF
--- a/website/static/css/landing.css
+++ b/website/static/css/landing.css
@@ -8,6 +8,8 @@
 html,body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif; }
 .btn-brand { background: var(--brand); border-color: var(--brand); }
 .btn-brand:hover { background: var(--brand-600); border-color: var(--brand-600); }
+.btn-subscribe { background: #16a34a; border-color: #16a34a; color: #fff; }
+.btn-subscribe:hover { background: #15803d; border-color: #15803d; color: #fff; }
 .text-ink { color: var(--ink-600); }
 .text-muted-adv { color: var(--muted); }
 .bg-soft { background: var(--bg-soft); }

--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -38,7 +38,9 @@
         <li class="nav-item"><a class="nav-link px-3" href="#shots">Capturas</a></li>
         <li class="nav-item"><a class="nav-link px-3" href="#pricing">Precios</a></li>
         <li class="nav-item"><a class="nav-link px-3" href="#faq">FAQ</a></li>
+        <li class="nav-item"><a class="nav-link px-3" href="{{ url_for('contacto') }}">Contacto</a></li>
         <li class="nav-item ms-lg-3"><a class="btn btn-outline-secondary" href="{{ url_for('login') }}">Iniciar sesión</a></li>
+        <li class="nav-item ms-lg-2"><a class="btn btn-subscribe" href="{{ url_for('subscribe') }}">Suscribirme (USD 50/mes)</a></li>
         <li class="nav-item ms-lg-2"><a class="btn btn-brand" href="{{ url_for('app_entry') }}">Entrar a la app</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Add "Contacto" nav item linked to the contact page.
- Highlight subscription CTA in navbar with new `.btn-subscribe` styling.

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689781cd6b60832785c41e2819b1d5c0