### PR TITLE
Add requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ seaborn==0.12.2
 openpyxl==3.1.2
 pulp==2.7.*
 psutil==5.9.5
+requests==2.31.0


### PR DESCRIPTION
## Summary
- add requests library to project requirements

## Testing
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_689781ce74148327b62d859ed5066d41