### PR TITLE
Add .env example and update setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Copia este archivo a `.env` y completa las credenciales reales antes de ejecutar la app.
+
+# Entorno de PayPal ("sandbox" o "live")
+PAYPAL_ENV=
+
+# ID de cliente de PayPal
+PAYPAL_CLIENT_ID=
+
+# Secreto de PayPal
+PAYPAL_SECRET=
+
+# ID del plan de suscripción de PayPal
+PAYPAL_SUB_PLAN_ID=
+
+# Correo electrónico del administrador
+ADMIN_EMAIL=
+
+# Host del servidor SMTP
+SMTP_HOST=
+
+# Puerto del servidor SMTP
+SMTP_PORT=
+
+# Usuario del servidor SMTP
+SMTP_USER=
+
+# Contraseña del servidor SMTP
+SMTP_PASS=
+
+# Clave secreta usada por Flask para firmar las sesiones
+SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.env

--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ This project creates optimized work schedules using Flask.
 
    The list includes the `pulp` package used for solving the optimization problem.
 
-2. Set the `SECRET_KEY` environment variable used to sign Flask sessions:
+2. Copia el archivo `.env.example` a `.env` y completa las credenciales reales:
    ```bash
-   export SECRET_KEY="replace-me"
+   cp .env.example .env
    ```
-   If this variable is omitted the application falls back to an insecure default and prints a warning.
+   Edita `.env` con los valores de `PAYPAL_ENV`, `PAYPAL_CLIENT_ID`,
+   `PAYPAL_SECRET`, `PAYPAL_SUB_PLAN_ID`, `ADMIN_EMAIL`, `SMTP_HOST`,
+   `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` y `SECRET_KEY` antes de ejecutar la
+   aplicación.
 
 3. Launch the Flask application:
    ```bash


### PR DESCRIPTION
## Summary
- Add `.env.example` with placeholders for PayPal, SMTP and Flask `SECRET_KEY` settings
- Document `.env` usage in README and ignore real `.env`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689781cf83d083279f487fe9c2867940