### PR TITLE
Update plan names and pricing

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -47,8 +47,8 @@ PAYPAL_BASE_URL = (
 
 # Available one-time payment plans (USD values)
 PLANS = {
-    "basic": 10.0,
-    "pro": 20.0,
+    "starter": 30.0,
+    "pro": 50.0,
 }
 
 SMTP_SERVER = os.getenv("SMTP_SERVER")


### PR DESCRIPTION
## Summary
- Rename `basic` plan to `starter` for frontend consistency
- Update one-time plan prices to $30 (starter) and $50 (pro)

## Testing
- `python -m py_compile website/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6897886715c8832780cbde643f770233