### PR TITLE
Make checkout amount dynamic

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -413,7 +413,7 @@ def checkout(plan):
         flash('Plan inválido')
         return redirect(url_for('contacto'))
     session['pending_plan'] = plan
-    amount = PLANS[plan]
+    amount = f"{PLANS[plan]:.2f}"
     return render_template('checkout.html', plan=plan, amount=amount)
 
 

--- a/website/templates/checkout.html
+++ b/website/templates/checkout.html
@@ -8,7 +8,7 @@
     createOrder: function(data, actions) {
       return actions.order.create({
         purchase_units: [{
-          amount: { value: '10.00' }
+          amount: { value: '{{ amount }}' }
         }]
       });
     },


### PR DESCRIPTION
## Summary
- Render dynamic amount in PayPal checkout template
- Format backend checkout amounts with two decimal places

## Testing
- `pytest -q`
- `python - <<'PY'
import sys, types
sys.modules['website.scheduler'] = types.ModuleType('scheduler')
from website.app import app
client = app.test_client()
import re
for plan in ['basic', 'pro']:
    res = client.get(f'/checkout/{plan}')
    print('plan', plan, 'status', res.status_code)
    text = res.get_data(as_text=True)
    match = re.search(r"amount: { value: '([0-9]+\.[0-9]{2})' }", text)
    print('amount found:', match.group(1) if match else 'not found')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897886d4c588327aa6657bc5c989457