### PR TITLE
Update pricing on landing page

### DIFF
--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -289,7 +289,7 @@
         <div class="card h-100">
           <div class="card-body p-4">
             <h5 class="fw-bold">Starter</h5>
-            <div class="display-6 fw-bold">$0</div>
+            <div class="display-6 fw-bold">$30</div>
             <div class="text-muted-adv mb-3">hasta 50 agentes</div>
             <ul class="list-unstyled small">
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Generador básico</li>
@@ -305,14 +305,14 @@
           <div class="card-body p-4">
             <div class="badge bg-primary-subtle text-primary mb-2">Recomendado</div>
             <h5 class="fw-bold">Pro</h5>
-            <div class="display-6 fw-bold">$29<span class="fs-6 text-muted">/mes</span></div>
+            <div class="display-6 fw-bold">$50<span class="fs-6 text-muted">/mes</span></div>
             <div class="text-muted-adv mb-3">hasta 500 agentes</div>
             <ul class="list-unstyled small">
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Perfiles avanzados</li>
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>JEAN personalizado</li>
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Métricas y heatmaps</li>
             </ul>
-            <a href="{{ url_for('checkout', plan='pro') }}" class="btn btn-brand w-100">Comenzar</a>
+            <a href="{{ url_for('checkout', plan='pro') }}" class="btn btn-brand w-100">Ir al checkout</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Update Starter and Pro plan prices to $30 and $50 respectively
- Clarify Pro button as a direct checkout link

## Testing
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_6897929151848327a74af0bf1f043496