### PR TITLE
Load .env configuration for PayPal credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+
+# secrets
 .env

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openpyxl==3.1.2
 pulp==2.7.*
 psutil==5.9.5
 requests==2.31.0
+python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- load variables from `.env` (with automatic copy from `.env.example`)
- switch SMTP environment variables to HOST/USER/PASS
- add `python-dotenv` dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979d73239c832792bae259c3cdbb33