### PR TITLE
Integrate PayPal checkout and subscription flows

### DIFF
--- a/website/templates/checkout.html
+++ b/website/templates/checkout.html
@@ -1,22 +1,36 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Pago</h1>
-<div id="paypal-button-container"></div>
-<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&currency=USD"></script>
+
+<div class="container-xxl py-4">
+  <h1 class="mb-3">Pago</h1>
+  <div class="alert alert-info">Monto: <strong>USD {{ '%.2f'|format(amount) }}</strong></div>
+  <div id="paypal-button-container"></div>
+</div>
+
+<!-- SDK de PayPal con client_id inyectado -->
+<script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&currency=USD&components=buttons&intent=capture{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
+
 <script>
-  paypal.Buttons({
-    createOrder: function(data, actions) {
-      return actions.order.create({
-        purchase_units: [{
-          amount: { value: '{{ amount }}' }
-        }]
-      });
-    },
-    onApprove: function(data, actions) {
-      return actions.order.capture().then(function(details) {
-        alert('Transacción completada por ' + details.payer.name.given_name);
-      });
-    }
-  }).render('#paypal-button-container');
+paypal.Buttons({
+  style: { layout: 'vertical', shape: 'rect', label: 'pay', color: 'gold' },
+
+  createOrder: (data, actions) => {
+    return actions.order.create({
+      purchase_units: [{ amount: { value: "{{ '%.2f'|format(amount) }}" } }]
+    });
+  },
+
+  onApprove: (data, actions) => {
+    return actions.order.capture().then((details) => {
+      alert("Pago completado por " + (details.payer?.name?.given_name || "el comprador"));
+      // TODO: llamar a tu backend para allowlist y notificación al admin
+    });
+  },
+
+  onError: (err) => {
+    console.error(err);
+    alert("Error con PayPal (consulta la consola del navegador).");
+  }
+}).render('#paypal-button-container');
 </script>
 {% endblock %}

--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -296,7 +296,7 @@
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Exportar a Excel</li>
                 <li><i class="bi bi-dash text-muted me-1" aria-hidden="true"></i><span class="visually-hidden">No incluido: </span>JEAN personalizado</li>
             </ul>
-            <a href="{{ url_for('checkout', plan='basic') }}" class="btn btn-outline-secondary w-100">Ir al checkout</a>
+            <a href="{{ url_for('checkout', plan='starter') }}" class="btn btn-outline-secondary w-100">Ir al checkout</a>
           </div>
         </div>
       </div>

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -9,14 +9,19 @@
 </form>
 
 <div id="paypal-button-container"></div>
-<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&vault=true&intent=subscription"></script>
+<script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&vault=true&intent=subscription{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
 <script>
   paypal.Buttons({
     createSubscription: function(data, actions) {
-      return actions.subscription.create({ plan_id: 'P-PLAN_ID' });
+      return actions.subscription.create({ plan_id: '{{ paypal_plan_id }}' });
     },
     onApprove: function(data, actions) {
       alert('Suscripción completada');
+      // TODO: llamar a tu backend para allowlist y notificación al admin
+    },
+    onError: function(err) {
+      console.error(err);
+      alert("Error con PayPal (consulta la consola del navegador).");
     }
   }).render('#paypal-button-container');
 </script>


### PR DESCRIPTION
## Summary
- load environment variables from `.env` and add optional SMTP handling
- add PayPal checkout and subscription routes/templates with dynamic client ID and plan ID
- adjust landing page checkout link for starter plan

## Testing
- `python -m py_compile website/app.py`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6897a52c58d88327a54ad2482c52f17e