### PR TITLE
feat: unify brand and theme toggle

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -64,44 +64,58 @@ body.dark-mode .navbar span {
   color: #fff;
 }
 
-.toast {
+ .toast {
   border-radius: 0.5rem;
-}
+ }
 
 :root{
-  --brand:#2d6cdf;      /* mismo tono de tu landing */
-  --ink:#1f2937;
-  --muted:#8a94a6;
+  --brand: #2d6cdf;
+  --brand-600:#1f5ad1;
+  --ink:   #111827;
+  --muted: #6b7280;
   --bg-soft:#f7f8fb;
+  --card:  #ffffff;
+  --card-bd:#eef1f6;
 }
 
-/* fondo suave como la landing */
+[data-bs-theme="dark"]{
+  --ink:   #e5e7eb;
+  --muted: #9aa4b2;
+  --bg-soft:#0f141b;
+  --card:  #1d2430;
+  --card-bd:#2a3240;
+}
+
+/* brand mark (igual en landing y checkout) */
+.brand-logo{
+  width:28px;height:28px;border-radius:8px;
+  background: linear-gradient(135deg,#dbeafe, #93c5fd 60%, #bfdbfe);
+  position:relative; display:inline-flex; align-items:center; justify-content:center;
+  box-shadow: 0 6px 16px rgba(37,99,235,.25);
+}
+.brand-spark{
+  width:8px;height:8px;border-radius:50%; background:#22d3ee;
+  box-shadow:0 0 0 4px rgba(34,211,238,.18), 0 0 22px rgba(34,211,238,.55);
+}
+
+/* botón de marca (si lo usas en navbar/landing) */
+.btn-brand{
+  background: var(--brand);
+  color:#fff;border:none; border-radius:10px; padding:.55rem .9rem; font-weight:600;
+}
+.btn-brand:hover{ background: var(--brand-600); color:#fff; }
+
+/* checkout layout (mismo estilo que landing) */
 .checkout-hero{ background: var(--bg-soft); }
+.shadow-soft{ box-shadow: 0 20px 45px rgba(0,0,0,.08); }
 
-/* sombras suaves */
-.shadow-soft{ box-shadow: 0 10px 30px rgba(17,24,39,.08); }
-
-/* puntito de marca */
-.badge-dot{ width:10px; height:10px; border-radius:50%; background:#00e0b8; display:inline-block; }
-
-/* chip de precio */
+.pay-card,.order-card{ background:var(--card); border:1px solid var(--card-bd); border-radius:18px; }
 .price-chip{
-  background: rgba(45,108,223,.08);
-  color: var(--brand);
-  font-weight: 700;
-  padding: .4rem .8rem;
-  border-radius: 999px;
+  background: rgba(45,108,223,.12); color:var(--brand);
+  font-weight:700; padding:.35rem .7rem; border-radius:999px;
 }
-
-/* línea de seguridad */
 .secure-line{
-  display:flex; align-items:center; gap:.5rem;
-  color: var(--muted);
-  background:#fff; border:1px solid #eef1f6; border-radius:12px;
-  padding:.75rem 1rem;
+  display:flex; align-items:center; gap:.5rem; color:var(--muted);
+  background:var(--card); border:1px solid var(--card-bd); border-radius:12px; padding:.7rem 1rem;
 }
 .secure-line .bi{ color:#16a34a; }
-
-/* cards principales */
-.pay-card,.order-card{ border-radius:20px; }
-.order-card .h4{ color: var(--ink); }

--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -1,34 +1,30 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const htmlEl = document.documentElement;
-  const body = document.body;
-  const themeToggle = document.getElementById('themeToggle');
-  const storedTheme = localStorage.getItem('theme');
+// Tema Bootstrap usando data-bs-theme en <html>
+(function () {
+  const root = document.documentElement;
+  const btn  = document.getElementById('themeToggle');
+  const saved = localStorage.getItem('theme') || 'light';
 
-  const applyTheme = (theme) => {
-    const isDark = theme === 'dark';
-    htmlEl.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
-    body.classList.toggle('dark-mode', isDark);
-    return isDark;
-  };
+  function apply(theme){
+    root.setAttribute('data-bs-theme', theme);
+    localStorage.setItem('theme', theme);
+    // icono
+    if(btn){
+      btn.innerHTML = theme === 'dark'
+        ? '<i class="bi bi-sun" aria-hidden="true"></i>'
+        : '<i class="bi bi-moon" aria-hidden="true"></i>';
+    }
+  }
+  apply(saved);
 
-  const initIsDark = applyTheme(storedTheme || 'light');
-
-  if (themeToggle) {
-    const icon = themeToggle.querySelector('i');
-    const updateIcon = (isDark) => {
-      if (!icon) return;
-      icon.classList.toggle('bi-moon', !isDark);
-      icon.classList.toggle('bi-sun', isDark);
-    };
-    updateIcon(initIsDark);
-    themeToggle.addEventListener('click', () => {
-      const isDark = body.classList.toggle('dark-mode');
-      htmlEl.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
-      updateIcon(isDark);
-      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  if(btn){
+    btn.addEventListener('click', () => {
+      const next = (root.getAttribute('data-bs-theme') === 'dark') ? 'light' : 'dark';
+      apply(next);
     });
   }
+})();
 
+document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('genForm');
   if (form) {
     form.addEventListener('submit', () => {

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -17,13 +17,18 @@
       <button class="navbar-toggler me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#drawer" aria-controls="drawer" aria-label="Abrir menú">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a class="navbar-brand d-flex align-items-center me-auto" href="/">
-        <i class="bi bi-calendar-check me-2" aria-hidden="true"></i>
-        <span class="fs-5 fw-semibold">Schedules</span>
-      </a>
-      <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
-        <i class="bi bi-moon" aria-hidden="true"></i>
-      </button>
+        <a class="navbar-brand d-flex align-items-center me-auto" href="/">
+          <span class="brand-logo me-2">
+            <span class="brand-spark"></span>
+          </span>
+          <span class="fs-5 fw-semibold">Schedules</span>
+        </a>
+        <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
+          <i class="bi bi-moon" aria-hidden="true"></i>
+        </button>
+        {% if request.endpoint != 'subscribe' %}
+          <a href="{{ url_for('subscribe') }}" class="btn btn-brand ms-3">Suscribirme (USD 50/mes)</a>
+        {% endif %}
       <div class="dropdown">
         {% set avatar = session.get('avatar_url') %}
         {% set username = session.get('user', 'Invitado') %}


### PR DESCRIPTION
## Summary
- standardize navbar branding and add subscription button
- centralize shared theme variables and checkout styles
- simplify JS theme toggle with persistent preference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b5991b4083279cfed010fef616b3