### PR TITLE
feat: refresh branding and hide CTA on landing and checkout pages

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -61,20 +61,6 @@ html,body {
 .offcanvas .nav-link.active, .offcanvas .nav-link:hover{ color: var(--brand); }
 
 /* =========================
-   MARCA (LOGO CUADRADO)
-   ========================= */
-.brand-logo{
-  width:28px;height:28px;border-radius:8px;
-  background: linear-gradient(135deg,#dbeafe,#93c5fd 60%,#bfdbfe);
-  position:relative; display:inline-flex; align-items:center; justify-content:center;
-  box-shadow: 0 6px 16px rgba(37,99,235,.25);
-}
-.brand-spark{
-  width:8px;height:8px;border-radius:50%; background:#22d3ee;
-  box-shadow:0 0 0 4px rgba(34,211,238,.18), 0 0 22px rgba(34,211,238,.55);
-}
-
-/* =========================
    BOTONES DE MARCA
    ========================= */
 .btn-brand{ /* azul (si lo usas en otras pantallas) */
@@ -112,5 +98,32 @@ html,body {
 .badge-dot{
   width:10px;height:10px;border-radius:50%;background:#00e676;
   box-shadow:0 0 0 3px rgba(0,230,118,.15);
+}
+
+/* === Logo empresa: puntito VERDE como en el landing === */
+.brand-dot{
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #16a34a; /* verde principal */
+  box-shadow:
+    0 0 0 3px rgba(22,163,74,.18),   /* halo */
+    0 0 18px rgba(22,163,74,.45);    /* glow */
+  display: inline-block;
+  flex: 0 0 auto;
+  transform: translateY(1px);
+  animation: brandPulse 2.4s ease-in-out infinite;
+}
+@keyframes brandPulse{
+  0%,100%{ box-shadow:0 0 0 3px rgba(22,163,74,.18), 0 0 18px rgba(22,163,74,.45); }
+  50%    { box-shadow:0 0 0 5px rgba(22,163,74,.12), 0 0 26px rgba(22,163,74,.60); }
+}
+
+/* contraste en modo oscuro */
+[data-bs-theme="dark"] .brand-dot{
+  background:#22c55e;
+  box-shadow:
+    0 0 0 3px rgba(34,197,94,.18),
+    0 0 22px rgba(34,197,94,.60);
 }
 

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -18,16 +18,18 @@
         <span class="navbar-toggler-icon"></span>
       </button>
         <a class="navbar-brand d-flex align-items-center me-auto" href="/">
-          <span class="brand-logo me-2">
-            <span class="brand-spark"></span>
-          </span>
+          <span class="brand-dot me-2" aria-hidden="true"></span>
           <span class="fs-5 fw-semibold">Schedules</span>
         </a>
         <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
           <i class="bi bi-moon" aria-hidden="true"></i>
         </button>
-        {% if request.endpoint != 'subscribe' %}
-          <a href="{{ url_for('subscribe') }}" class="btn btn-subscribe ms-3">Suscribirme (USD 50/mes)</a>
+        {# Oculta el CTA en landing, home e interfaces de pago #}
+        {% set _hide_cta = request.endpoint in ['landing', 'index', 'checkout', 'subscribe'] %}
+        {% if not _hide_cta %}
+          <a href="{{ url_for('subscribe') }}" class="btn btn-subscribe ms-3">
+            Suscribirme (USD 50/mes)
+          </a>
         {% endif %}
       <div class="dropdown">
         {% set avatar = session.get('avatar_url') %}


### PR DESCRIPTION
## Summary
- replace header logo with green dot brand
- hide subscribe CTA on landing, home, checkout
- add CSS for animated brand dot and remove old logo styles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c493d7c483278b0c94ccc3daec58