### PR TITLE
Embed inline checkout on landing and refine auth UI

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -249,9 +249,16 @@ def _on(name: str) -> bool:
     return v is not None and str(v).lower() in {'on', '1', 'true', 'yes'}
 
 
-@app.route('/', methods=['GET'])
+@app.route('/')
 def landing():
-    return render_template('landing.html', title='Schedules', year=datetime.now().year)
+    return render_template(
+        'landing.html',
+        title='Schedules',
+        paypal_client_id=PAYPAL_CLIENT_ID,
+        paypal_plan_id=PAYPAL_SUB_PLAN_ID,
+        paypal_env=PAYPAL_ENV,
+        year=datetime.now().year,
+    )
 
 
 @app.route('/app', methods=['GET'])
@@ -277,7 +284,7 @@ def register():
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
-        user_email = request.form['username']
+        user_email = request.form['email']
         pw = request.form['password']
         if users.get(user_email) == pw:
             if not is_allowed(user_email):

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -127,3 +127,13 @@ html,body {
     0 0 22px rgba(34,197,94,.60);
 }
 
+/* Auth */
+.auth-hero{min-height:calc(100vh - 80px);display:grid;grid-template-columns:1fr 1fr}
+.auth-side{
+  background:linear-gradient(135deg,#f0fdf4,#dcfce7);
+  display:flex;align-items:center;justify-content:center;flex-direction:column;text-align:center;padding:2rem
+}
+[data-bs-theme="dark"] .auth-side{background:linear-gradient(135deg,#0f1410,#17211a)}
+.auth-form{display:flex;align-items:center;justify-content:center;padding:2rem}
+.auth-card{width:100%;max-width:420px}
+

--- a/website/templates/_checkout_inline.html
+++ b/website/templates/_checkout_inline.html
@@ -1,0 +1,65 @@
+<section id="checkout" class="checkout-hero py-4">
+  <div class="container-xxl">
+    <div class="row g-4">
+      <div class="col-lg-7">
+        <div class="card pay-card p-4 shadow-soft">
+          <div class="d-flex align-items-center mb-3">
+            <span class="badge-dot me-2"></span>
+            <h4 class="mb-0">Pagar</h4>
+            <span class="ms-auto price-chip fw-bold">USD 50.00</span>
+          </div>
+
+          <div class="secure-line mb-3">
+            <i class="bi bi-shield-check"></i>
+            <small>Pago seguro con PayPal. No compartimos tus datos financieros.</small>
+          </div>
+
+          <div id="paypal-button-pro"></div>
+
+          <p class="text-muted mt-3 mb-0" style="font-size:.9rem;">
+            Al continuar aceptas nuestros Términos y Política de privacidad. Recibirás el comprobante por correo.
+          </p>
+        </div>
+      </div>
+
+      <div class="col-lg-5">
+        <div class="card order-card p-4 shadow-soft">
+          <div class="d-flex align-items-center mb-3">
+            <h5 class="mb-0">Resumen del pedido</h5>
+            <span class="ms-2 badge text-bg-secondary">Pro</span>
+          </div>
+          <ul class="list-unstyled text-muted">
+            <li class="mb-1"><i class="bi bi-check2 me-2 text-success"></i>Perfiles avanzados</li>
+            <li class="mb-1"><i class="bi bi-check2 me-2 text-success"></i>JEAN personalizado</li>
+            <li class="mb-1"><i class="bi bi-check2 me-2 text-success"></i>Métricas y heatmaps</li>
+          </ul>
+
+          <hr class="my-3">
+          <div class="d-flex align-items-center">
+            <small class="text-muted me-2"><i class="bi bi-envelope-open"></i> ¿Dudas?</small>
+            <a href="{{ url_for('contacto') }}" class="small">Contáctanos</a>
+            <span class="ms-auto fw-semibold">USD 50.00</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# SDK y botón de suscripción #}
+<script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&vault=true&intent=subscription&components=buttons{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
+<script>
+  paypal.Buttons({
+    style:{ layout:'vertical', color:'blue', shape:'rect', label:'subscribe' },
+    createSubscription: function(data, actions){
+      return actions.subscription.create({ plan_id: '{{ paypal_plan_id }}' }); // <- tu plan (P-...)
+    },
+    onApprove: function(data, actions){
+      window.location.href = "{{ url_for('subscribe_success') }}?sub=" + data.subscriptionID;
+    },
+    onError: function(err){
+      console.error(err);
+      alert('Hubo un problema iniciando la suscripción.');
+    }
+  }).render('#paypal-button-pro');
+</script>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,37 +1,42 @@
 <!doctype html>
-<html lang="en" data-bs-theme="light">
+<html lang="es" data-bs-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ title or 'Horarios' }}</title>
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
 <body>
+  {% set is_public = request.endpoint in ['landing','index','checkout'] %}
+  {% set is_auth   = session.get('user') %}
+
   <header class="navbar bg-body-tertiary sticky-top border-bottom">
     <div class="container-fluid">
-      <button class="navbar-toggler me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#drawer" aria-controls="drawer" aria-label="Abrir menú">
-        <span class="navbar-toggler-icon"></span>
+
+      {# BRAND — puntito verde + texto #}
+      <a class="navbar-brand d-flex align-items-center me-auto" href="/">
+        <span class="brand-dot me-2" aria-hidden="true"></span>
+        <span class="fs-5 fw-semibold">Schedules</span>
+      </a>
+
+      <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
+        <i class="bi bi-moon" aria-hidden="true"></i>
       </button>
-        <a class="navbar-brand d-flex align-items-center me-auto" href="/">
-          <span class="brand-dot me-2" aria-hidden="true"></span>
-          <span class="fs-5 fw-semibold">Schedules</span>
-        </a>
-        <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
-          <i class="bi bi-moon" aria-hidden="true"></i>
-        </button>
-        {# Oculta el CTA en landing, home e interfaces de pago #}
-        {% set _hide_cta = request.endpoint in ['landing', 'index', 'checkout', 'subscribe'] %}
-        {% if not _hide_cta %}
-          <a href="{{ url_for('subscribe') }}" class="btn btn-subscribe ms-3">
-            Suscribirme (USD 50/mes)
-          </a>
-        {% endif %}
-      <div class="dropdown">
+
+      {# CTA del header: oculto en landing/checkout (allí ya hay planes/checkout inline) #}
+      {% set _hide_cta = is_public %}
+      {% if not _hide_cta %}
+        <a href="{{ url_for('subscribe') }}" class="btn btn-subscribe ms-3">Suscribirme (USD 50/mes)</a>
+      {% endif %}
+
+      {# PERFIL #}
+      <div class="dropdown ms-3">
         {% set avatar = session.get('avatar_url') %}
         {% set username = session.get('user', 'Invitado') %}
         <a href="#" class="d-flex align-items-center text-decoration-none" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -45,12 +50,24 @@
         <ul class="dropdown-menu dropdown-menu-end">
           <li><a class="dropdown-item" href="{{ url_for('configuracion') }}">Perfil</a></li>
           <li><hr class="dropdown-divider"></li>
-          <li><a class="dropdown-item" href="{{ url_for('logout') }}">Salir</a></li>
+          {% if is_auth %}
+            <li><a class="dropdown-item" href="{{ url_for('logout') }}">Salir</a></li>
+          {% else %}
+            <li><a class="dropdown-item" href="{{ url_for('login') }}">Iniciar sesión</a></li>
+          {% endif %}
         </ul>
       </div>
+
+      {# HAMBURGUESA / OFFCANVAS: solo en páginas internas y si hay usuario #}
+      {% if not is_public and is_auth %}
+        <button class="navbar-toggler ms-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#drawer" aria-controls="drawer" aria-label="Abrir menú">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+      {% endif %}
     </div>
   </header>
 
+  {% if not is_public and is_auth %}
   <div class="offcanvas offcanvas-start" tabindex="-1" id="drawer" aria-labelledby="drawerLabel">
     <div class="offcanvas-header">
       <h5 class="offcanvas-title" id="drawerLabel">Menú</h5>
@@ -64,6 +81,7 @@
       </nav>
     </div>
   </div>
+  {% endif %}
 
   <main class="container-xxl py-4">
     {% block content %}{% endblock %}

--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -41,7 +41,7 @@
         <li class="nav-item"><a class="nav-link px-3" href="{{ url_for('contacto') }}">Contacto</a></li>
         <li class="nav-item ms-lg-3"><a class="btn btn-outline-secondary" href="{{ url_for('login') }}">Iniciar sesión</a></li>
         <li class="nav-item ms-lg-2"><a class="btn btn-subscribe" href="{{ url_for('subscribe') }}">Suscribirme (USD 50/mes)</a></li>
-        <li class="nav-item ms-lg-2"><a class="btn btn-brand" href="{{ url_for('checkout', plan='pro') }}">Ir al checkout</a></li>
+        <li class="nav-item ms-lg-2"><a class="btn btn-brand" href="#checkout">Ir al checkout</a></li>
       </ul>
     </div>
   </div>
@@ -296,7 +296,7 @@
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Exportar a Excel</li>
                 <li><i class="bi bi-dash text-muted me-1" aria-hidden="true"></i><span class="visually-hidden">No incluido: </span>JEAN personalizado</li>
             </ul>
-            <a href="{{ url_for('checkout', plan='starter') }}" class="btn btn-outline-secondary w-100">Ir al checkout</a>
+            <a href="#checkout" class="btn btn-outline-secondary w-100">Ir al checkout</a>
           </div>
         </div>
       </div>
@@ -312,7 +312,7 @@
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>JEAN personalizado</li>
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Métricas y heatmaps</li>
             </ul>
-            <a href="{{ url_for('checkout', plan='pro') }}" class="btn btn-brand w-100">Ir al checkout</a>
+            <a href="#checkout" class="btn btn-brand w-100">Ir al checkout</a>
           </div>
         </div>
       </div>
@@ -334,6 +334,8 @@
     </div>
   </div>
 </section>
+
+{% include '_checkout_inline.html' %}
 
 <!-- FAQ -->
 <section id="faq" class="py-5">

--- a/website/templates/login.html
+++ b/website/templates/login.html
@@ -1,57 +1,36 @@
-<!doctype html>
-<html lang="es" data-bs-theme="light">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Login</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    body { font-family: 'Inter', sans-serif; }
-  </style>
-</head>
-<body>
-  <div class="container-fluid">
-    <div class="row min-vh-100">
-      <div class="col-md-6 d-none d-md-flex bg-light align-items-center justify-content-center">
-        <div class="text-center">
-          <h1 class="display-4 fw-bold">Schedules</h1>
-          <p class="lead">Organiza tus horarios de manera sencilla</p>
-        </div>
+{% extends "base.html" %}
+{% block content %}
+<section class="auth-hero">
+  <div class="auth-side">
+    <div>
+      <div class="d-inline-flex align-items-center mb-3">
+        <span class="brand-dot me-2"></span>
+        <span class="fw-semibold">Schedules</span>
       </div>
-      <div class="col-md-6 d-flex align-items-center justify-content-center p-4">
-        <div class="w-100" style="max-width: 360px;">
-          {% with messages = get_flashed_messages() %}
-            {% if messages %}
-              {% for message in messages %}
-                <div class="alert alert-info alert-dismissible fade show" role="alert">
-                  {{ message }}
-                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-              {% endfor %}
-            {% endif %}
-          {% endwith %}
-          <form action="{{ url_for('login') }}" method="post">
-            <h2 class="mb-4 text-center">Iniciar sesi\u00f3n</h2>
-            <div class="mb-3">
-              <input type="text" name="username" placeholder="Usuario" class="form-control" required>
-            </div>
-            <div class="mb-3">
-              <input type="password" name="password" placeholder="Contrase\u00f1a" class="form-control" required>
-            </div>
-            <button type="submit" class="btn btn-primary w-100">Entrar</button>
-          </form>
-          <p class="text-center mt-3 mb-0">
-            <a href="{{ url_for('login') }}" class="text-decoration-none me-2">Login</a>
-            <span class="text-muted">·</span>
-            <a href="{{ url_for('register') }}" class="text-decoration-none ms-2">Registro</a>
-          </p>
+      <h1 class="fw-bold mb-2">Organiza tus horarios de manera sencilla</h1>
+      <p class="text-muted mb-0">Accede con tu cuenta para continuar.</p>
+    </div>
+  </div>
+
+  <div class="auth-form">
+    <div class="card auth-card p-4 shadow-soft">
+      <h4 class="mb-3">Iniciar sesión</h4>
+      <form method="post" action="{{ url_for('login') }}">
+        <div class="mb-3">
+          <label class="form-label">Correo</label>
+          <input name="email" type="email" class="form-control" required placeholder="tucorreo@ejemplo.com" value="{{ request.form.get('email','') }}">
         </div>
+        <div class="mb-3">
+          <label class="form-label">Contraseña</label>
+          <input name="password" type="password" class="form-control" required placeholder="••••••••">
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Entrar</button>
+      </form>
+      <div class="d-flex justify-content-center gap-2 small mt-3">
+        <a href="{{ url_for('login') }}">Login</a> ·
+        <a href="{{ url_for('register') }}">Registro</a>
       </div>
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Replace base layout with flexible header that hides navigation when unauthenticated and uses green dot logo
- Embed PayPal subscription checkout directly in landing and update links to scroll to it
- Redesign login page and styles, including email-based login handling

## Testing
- `pytest`
- `python -m py_compile website/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6897c7cd5d4883278d0d8cbe6ff5b1a9