### PR TITLE
Add PayPal subscription success page

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -499,6 +499,16 @@ def subscribe():
     )
 
 
+@app.get("/subscribe/success")
+def subscribe_success():
+    sub_id = request.args.get("sub", "")
+    return render_template(
+        "subscribe_success.html",
+        subscription_id=sub_id,
+        title="Suscripción exitosa",
+    )
+
+
 @app.route('/api/paypal/subscription-activate', methods=['POST'])
 def paypal_subscription_activate():
     data = request.get_json(silent=True) or {}

--- a/website/templates/_checkout_inline.html
+++ b/website/templates/_checkout_inline.html
@@ -55,7 +55,9 @@
       return actions.subscription.create({ plan_id: '{{ paypal_plan_id }}' }); // <- tu plan (P-...)
     },
     onApprove: function(data, actions){
-      window.location.href = "{{ url_for('subscribe_success') }}?sub=" + data.subscriptionID;
+      window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(data.subscriptionID);
+      // Fallback si no se desea una página de éxito dedicada:
+      // window.location.href = "{{ url_for('landing') }}?sub=" + encodeURIComponent(data.subscriptionID);
     },
     onError: function(err){
       console.error(err);

--- a/website/templates/subscribe_success.html
+++ b/website/templates/subscribe_success.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="text-center py-5">
+  <h1 class="mb-4">¡Suscripción completa!</h1>
+  {% if subscription_id %}
+  <p class="lead">ID de suscripción: <code>{{ subscription_id }}</code></p>
+  {% endif %}
+  {% if session.get('user') %}
+    <a href="{{ url_for('generador') }}" class="btn btn-primary mt-3">Ir al generador</a>
+  {% else %}
+    <a href="{{ url_for('login') }}" class="btn btn-primary mt-3">Iniciar sesión</a>
+  {% endif %}
+  <p class="mt-4"><a href="{{ url_for('landing') }}">Volver al inicio</a></p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `/subscribe/success` endpoint to display subscription ID
- Provide success template with links for logged-in and guest users
- URL-encode PayPal subscription ID in checkout redirect with fallback comment

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897cb77494c83278e62fbc7a931ee5a