### PR TITLE
Use email instead of username for registration

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -275,7 +275,7 @@ def app_entry():
 @app.route('/register', methods=['GET', 'POST'])
 def register():
     if request.method == 'POST':
-        users[request.form['username']] = request.form['password']
+        users[request.form['email']] = request.form['password']
         flash('Usuario creado. Ingrese ahora.')
         return redirect(url_for('login'))
     return render_template('register.html')
@@ -284,13 +284,13 @@ def register():
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
-        user_email = request.form['email']
+        email = request.form['email']
         pw = request.form['password']
-        if users.get(user_email) == pw:
-            if not is_allowed(user_email):
+        if users.get(email) == pw:
+            if not is_allowed(email):
                 flash('Correo no autorizado')
                 return render_template('login.html')
-            session['user'] = user_email
+            session['user'] = email
             return redirect(url_for('generador'))
         flash('Credenciales invalidas')
     return render_template('login.html')

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -38,14 +38,14 @@
       {# PERFIL #}
       <div class="dropdown ms-3">
         {% set avatar = session.get('avatar_url') %}
-        {% set username = session.get('user', 'Invitado') %}
+        {% set user_email = session.get('user', 'Invitado') %}
         <a href="#" class="d-flex align-items-center text-decoration-none" role="button" data-bs-toggle="dropdown" aria-expanded="false">
           {% if avatar %}
             <img src="{{ avatar }}" class="rounded-circle me-2" alt="avatar" width="32" height="32">
           {% else %}
             <i class="bi bi-person-circle fs-4 me-2" aria-hidden="true"></i>
           {% endif %}
-          <span>{{ username }} ▾</span>
+          <span>{{ user_email }} ▾</span>
         </a>
         <ul class="dropdown-menu dropdown-menu-end">
           <li><a class="dropdown-item" href="{{ url_for('configuracion') }}">Perfil</a></li>

--- a/website/templates/register.html
+++ b/website/templates/register.html
@@ -3,7 +3,7 @@
 <h2>Registro</h2>
 <form method="post">
   <div class="mb-3">
-    <input type="text" name="username" placeholder="Usuario" class="form-control" required>
+      <input type="email" name="email" placeholder="Correo" class="form-control" required>
   </div>
   <div class="mb-3">
     <input type="password" name="password" placeholder="Contrase\u00f1a" class="form-control" required>


### PR DESCRIPTION
## Summary
- Store registered users by email and authenticate using email
- Replace username form field with email input
- Show logged-in email in header and remove leftover username references

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d0bbeb3083278e1f294f80aca665