### PR TITLE
Include subscribe in public pages

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
 <body>
-  {% set is_public = request.endpoint in ['landing','index','checkout'] %}
+  {% set is_public = request.endpoint in ['landing','index','checkout','subscribe'] %}
   {% set is_auth   = session.get('user') %}
 
   <header class="navbar bg-body-tertiary sticky-top border-bottom">


### PR DESCRIPTION
## Summary
- Avoid showing header CTA on the subscribe view by including `subscribe` in `is_public` checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from flask import Flask, render_template
app = Flask(__name__, template_folder='website/templates')
app.add_url_rule('/', 'landing', lambda: 'ok')
for endpoint in ['subscribe','login','configuracion','logout','generador','resultados']:
    app.add_url_rule(f'/{endpoint}', endpoint, lambda: 'ok')

with app.test_request_context('/'):
    html = render_template('base.html')
    print('landing CTA', 'btn-subscribe' in html)

with app.test_request_context('/subscribe'):
    html = render_template('base.html')
    print('subscribe CTA', 'btn-subscribe' in html)

with app.test_request_context('/login'):
    html = render_template('base.html')
    print('login CTA', 'btn-subscribe' in html)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6897d0bcd8fc83279a8e6df916f2830d