### PR TITLE
Handle missing PayPal subscription plan

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -251,11 +251,14 @@ def _on(name: str) -> bool:
 
 @app.route('/')
 def landing():
+    plan_id = PAYPAL_SUB_PLAN_ID if PAYPAL_SUB_PLAN_ID else None
+    if plan_id is None:
+        app.logger.warning("PAYPAL_SUB_PLAN_ID missing; PayPal button disabled on landing")
     return render_template(
         'landing.html',
         title='Schedules',
         paypal_client_id=PAYPAL_CLIENT_ID,
-        paypal_plan_id=PAYPAL_SUB_PLAN_ID,
+        paypal_plan_id=plan_id,
         paypal_env=PAYPAL_ENV,
         year=datetime.now().year,
     )
@@ -490,11 +493,14 @@ def checkout(plan):
 
 @app.get("/subscribe")
 def subscribe():
+    plan_id = PAYPAL_SUB_PLAN_ID if PAYPAL_SUB_PLAN_ID else None
+    if plan_id is None:
+        app.logger.warning("PAYPAL_SUB_PLAN_ID missing; PayPal button disabled on subscribe")
     return render_template(
         "subscribe.html",
         paypal_client_id=PAYPAL_CLIENT_ID,
         paypal_env=PAYPAL_ENV,
-        paypal_plan_id=PAYPAL_SUB_PLAN_ID,
+        paypal_plan_id=plan_id,
         title="Suscripción"
     )
 

--- a/website/templates/_checkout_inline.html
+++ b/website/templates/_checkout_inline.html
@@ -14,11 +14,15 @@
             <small>Pago seguro con PayPal. No compartimos tus datos financieros.</small>
           </div>
 
+          {% if paypal_plan_id %}
           <div id="paypal-button-pro"></div>
 
           <p class="text-muted mt-3 mb-0" style="font-size:.9rem;">
             Al continuar aceptas nuestros Términos y Política de privacidad. Recibirás el comprobante por correo.
           </p>
+          {% else %}
+          <div class="alert alert-warning mb-0">Configuración de PayPal pendiente.</div>
+          {% endif %}
         </div>
       </div>
 
@@ -46,6 +50,7 @@
   </div>
 </section>
 
+{% if paypal_plan_id %}
 {# SDK y botón de suscripción #}
 <script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&vault=true&intent=subscription&components=buttons{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
 <script>
@@ -65,3 +70,4 @@
     }
   }).render('#paypal-button-pro');
 </script>
+{% endif %}

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -18,11 +18,15 @@
               <span>Pago seguro con PayPal. No compartimos tus datos financieros.</span>
             </div>
 
+            {% if paypal_plan_id %}
             <div id="paypal-subscribe-btn"></div>
 
             <p class="small text-muted mt-3 mb-0">
               Al continuar aceptas nuestros Términos y Política de privacidad. Recibirás el comprobante por correo.
             </p>
+            {% else %}
+            <div class="alert alert-warning mb-0">Configuración de PayPal pendiente.</div>
+            {% endif %}
           </div>
         </div>
       </div>
@@ -60,6 +64,7 @@
   </div>
 </section>
 
+{% if paypal_plan_id %}
 <script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&vault=true&intent=subscription&disable-funding=card,credit,venmo{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
 <script>
 paypal.Buttons({
@@ -69,6 +74,7 @@ paypal.Buttons({
   onError:(err)=>{ console.error(err); alert("Error con PayPal"); }
 }).render('#paypal-subscribe-btn');
 </script>
+{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Avoid rendering PayPal buttons when PAYPAL_SUB_PLAN_ID is not configured
- Display configuration warning message on landing and subscription pages
- Log missing plan to aid diagnostics

## Testing
- `python -m py_compile website/app.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d0bcee8c83279b30f8fceb6b09ba