### PR TITLE
feat: streamline subscription flow

### DIFF
--- a/website/templates/_checkout_inline.html
+++ b/website/templates/_checkout_inline.html
@@ -54,15 +54,31 @@
 {# SDK y botón de suscripción #}
 <script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&vault=true&intent=subscription&components=buttons{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
 <script>
+  console.log('PLAN', '{{ paypal_plan_id }}');
   paypal.Buttons({
     style:{ layout:'vertical', color:'blue', shape:'rect', label:'subscribe' },
     createSubscription: function(data, actions){
       return actions.subscription.create({ plan_id: '{{ paypal_plan_id }}' }); // <- tu plan (P-...)
     },
-    onApprove: function(data, actions){
-      window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(data.subscriptionID);
-      // Fallback si no se desea una página de éxito dedicada:
-      // window.location.href = "{{ url_for('landing') }}?sub=" + encodeURIComponent(data.subscriptionID);
+    onApprove: function(data){
+      fetch('/api/paypal/subscription-activate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subscription_id: data.subscriptionID })
+      })
+      .then(res => {
+        if(!res.ok) throw new Error('activation failed');
+        return res.json();
+      })
+      .then(() => {
+        window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(data.subscriptionID);
+        // Fallback si no se desea una página de éxito dedicada:
+        // window.location.href = "{{ url_for('landing') }}?sub=" + encodeURIComponent(data.subscriptionID);
+      })
+      .catch(err => {
+        console.error(err);
+        alert('Hubo un problema activando la suscripción.');
+      });
     },
     onError: function(err){
       console.error(err);

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -67,7 +67,7 @@
 {% if paypal_plan_id %}
 <script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&vault=true&intent=subscription&disable-funding=card,credit,venmo{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
 <script>
-const sessionUser = {{ (session.get('user') or '') | tojson }};
+console.log('PLAN', '{{ paypal_plan_id }}');
 paypal.Buttons({
   style:{ layout:'vertical', shape:'rect', label:'subscribe', color:'blue', tagline:false },
   createSubscription:(data, actions)=> actions.subscription.create({ plan_id: "{{ paypal_plan_id }}" }),
@@ -75,7 +75,7 @@ paypal.Buttons({
     fetch('/api/paypal/subscription-activate', {
       method:'POST',
       headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({subscriptionID:data.subscriptionID, email:sessionUser})
+      body: JSON.stringify({ subscription_id: data.subscriptionID })
     })
     .then(res=>{
       if(!res.ok) throw new Error('activation failed');


### PR DESCRIPTION
## Summary
- use purely client-side PayPal subscription creation with plan ID
- register subscription on approval via `/api/paypal/subscription-activate`
- log PayPal plan ID before rendering buttons for debugging

## Testing
- `pytest`
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*


------
https://chatgpt.com/codex/tasks/task_e_6897d617cadc832796677b5318c3a632