### PR TITLE
Improve PayPal activation error logging

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -538,9 +538,9 @@ def paypal_subscription_activate():
     try:
         sub = paypal_get_subscription(sub_id)
     except Exception as e:
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'error': 'failed to retrieve subscription', 'details': str(e)}), 400
     if sub.get('status') != 'ACTIVE':
-        return jsonify({'error': 'subscription not active'}), 400
+        return jsonify({'error': 'subscription not active', 'details': sub}), 400
     add_subscription_record(email, sub_id, sub.get('status', ''))
     add_to_allowlist(email)
     send_admin_email('Nueva suscripción', f'{email} activó la suscripción {sub_id}')

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -77,15 +77,18 @@ paypal.Buttons({
       headers:{'Content-Type':'application/json'},
       body: JSON.stringify({subscriptionID:data.subscriptionID, email:sessionUser})
     })
-    .then(res=>{
-      if(!res.ok) throw new Error('activation failed');
+    .then(async res=>{
+      if(!res.ok){
+        const msg = await res.text();
+        throw new Error(msg || 'activation failed');
+      }
       return res.json();
     })
     .then(()=>{
       window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(data.subscriptionID);
     })
     .catch(err=>{
-      console.error(err);
+      console.error('PayPal activation error:', err.message || err);
       alert("Error con PayPal");
     });
   },


### PR DESCRIPTION
## Summary
- Log detailed messages when PayPal subscription activation fails on the frontend
- Return structured error details from `/api/paypal/subscription-activate`

## Testing
- `python -m py_compile website/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6897d61ce05083278cd32126085bef0e