### PR TITLE
refactor: improve PayPal subscription handling

### DIFF
--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -68,7 +68,8 @@
 <script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&components=buttons&vault=true&intent=subscription{% if paypal_env=='sandbox' %}&debug=true{% endif %}"></script>
 <script>
 console.log('PAYPAL_ENV:', '{{ paypal_env }}');
-console.log('PLAN_ID:', '{{ paypal_plan_id }}');
+const PLAN_ID = "{{ paypal_plan_id|trim|e }}";
+console.log('PLAN_ID:', PLAN_ID);
 console.log('CLIENT_ID present:', '{{ paypal_client_id }}'.length > 10);
 
 paypal.Buttons({
@@ -76,7 +77,7 @@ paypal.Buttons({
 
   createSubscription: (data, actions) => {
     return actions.subscription.create({
-      plan_id: "{{ paypal_plan_id }}"
+      plan_id: PLAN_ID
     }).catch(err => {
       console.error('createSubscription failed:', err);
       alert('No se pudo iniciar la suscripción (createSubscription).');
@@ -85,14 +86,15 @@ paypal.Buttons({
   },
 
   onApprove: async (data) => {
+    const sub = data.subscriptionID || data.subscriptionId;
     try {
       const res = await fetch('/api/paypal/subscription-activate', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ subscription_id: data.subscriptionID })
+        body: JSON.stringify({ subscription_id: sub })
       });
       if (!res.ok) throw new Error(await res.text());
-      window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(data.subscriptionID);
+      window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(sub);
     } catch (err) {
       console.error('activation error:', err);
       alert('Error con PayPal al activar.');


### PR DESCRIPTION
## Summary
- Centralize PayPal plan ID in a constant and log for debugging
- Use fallback subscription ID from PayPal callbacks before activation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897edcefe488327bdd6e19e162087b2