### PR TITLE
Log PayPal plan ID at startup

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -62,6 +62,8 @@ PLANS = {"starter": 30.0, "pro": 50.0}
 
 app = Flask(__name__)
 app.secret_key = SECRET_KEY
+app.logger.setLevel("INFO")
+app.logger.info("PAYPAL_SUB_PLAN_ID repr: %r", PAYPAL_SUB_PLAN_ID)
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 ALLOWLIST_FILE = DATA_DIR / "allowlist.json"


### PR DESCRIPTION
## Summary
- Log PAYPAL_SUB_PLAN_ID during Flask app initialization for easier debugging

## Testing
- `pytest`
- `python run.py`

------
https://chatgpt.com/codex/tasks/task_e_6897edd003a08327bd83547a956b05ea