### PR TITLE
Remove subscription CTA from base header

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -69,13 +69,6 @@ html,body {
 }
 .btn-brand:hover{ background: var(--brand-600); border-color: var(--brand-600); color:#fff; }
 
-/* verde del landing — ahora global */
-.btn-subscribe{
-  background:#16a34a; border-color:#16a34a; color:#fff;
-  border:none; border-radius:10px; padding:.55rem .9rem; font-weight:600;
-}
-.btn-subscribe:hover{ background:#15803d; border-color:#15803d; color:#fff; }
-
 /* =========================
    CHECKOUT LOOK & FEEL
    ========================= */

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -32,7 +32,6 @@
       {# CTA del header: oculto en landing/checkout (allí ya hay planes/checkout inline) #}
       {% set _hide_cta = is_public %}
       {% if not _hide_cta %}
-        <a href="{{ url_for('subscribe') }}" class="btn btn-subscribe ms-3">Suscribirme (USD 50/mes)</a>
       {% endif %}
 
       {# PERFIL #}


### PR DESCRIPTION
## Summary
- drop Subscribe button from base template header
- clean up unused `.btn-subscribe` style definitions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898053cd30883279aafe63a3816fe54