### PR TITLE
Simplify login template by removing registration and password

### DIFF
--- a/website/templates/login.html
+++ b/website/templates/login.html
@@ -20,15 +20,10 @@
           <label class="form-label">Correo</label>
           <input name="email" type="email" class="form-control" required placeholder="tucorreo@ejemplo.com" value="{{ request.form.get('email','') }}">
         </div>
-        <div class="mb-3">
-          <label class="form-label">Contraseña</label>
-          <input name="password" type="password" class="form-control" required placeholder="••••••••">
-        </div>
         <button type="submit" class="btn btn-primary w-100">Entrar</button>
       </form>
       <div class="d-flex justify-content-center gap-2 small mt-3">
-        <a href="{{ url_for('login') }}">Login</a> ·
-        <a href="{{ url_for('register') }}">Registro</a>
+        <a href="{{ url_for('login') }}">Login</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- simplify login template by removing password field
- drop registration link, leaving only login link

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68980543e0988327a433411a422b32da