### PR TITLE
Add helper script for hashing allowlist passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ This project creates optimized work schedules using Flask.
 5. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
 6. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
 
+## Allowlist
+
+User passwords for the generator are stored as hashes in `data/allowlist.json`.
+If you prefer to edit this file manually, generate the hash with the helper
+script:
+
+```bash
+python scripts/hash_password.py "my-secret-password"
+```
+
+Paste the printed hash into `data/allowlist.json` next to the desired email
+address.
+
 ## Excel Input
 
 The expected Excel file `Requerido.xlsx` must contain a column named `Día` with values from 1 to 7 and a column `Suma de Agentes Requeridos Erlang` representing the hourly staffing requirements.

--- a/scripts/hash_password.py
+++ b/scripts/hash_password.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Generate a Werkzeug password hash for a given plaintext password."""
+
+from argparse import ArgumentParser
+from werkzeug.security import generate_password_hash
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Hash a plaintext password")
+    parser.add_argument("password", help="Plaintext password to hash")
+    args = parser.parse_args()
+
+    hashed = generate_password_hash(args.password)
+    print(hashed)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/hash_password.py` CLI to generate Werkzug password hashes
- document manual allowlist editing and password hashing helper in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68981cf8b03883279bc096f569516944