### PR TITLE
Add password hashing utility script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Each entry maps an email to a password hash produced by
 `generate_password_hash()` from Werkzeug, so the plaintext password is never
 saved.
 
+To hash a password manually run:
+
+```bash
+python scripts/hash_password.py <password>
+```
+
+The command prints the hashed string so it can be copied into
+`data/allowlist.json`.
+
 To add a new user:
 
 1. Set the target app:

--- a/scripts/hash_password.py
+++ b/scripts/hash_password.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Hash a password for manual insertion into data/allowlist.json.
+
+This script accepts a single positional argument (the plaintext password),
+uses ``werkzeug.security.generate_password_hash`` to hash it and prints the
+result to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+from werkzeug.security import generate_password_hash
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Hash a password using Werkzeug")
+    parser.add_argument("password", help="Plaintext password to hash")
+    args = parser.parse_args()
+    hashed = generate_password_hash(args.password)
+    print(hashed)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/hash_password.py` to hash passwords for manual allowlist updates.
- Document usage of the script in README.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689826c5c6a08327aaae3544de301cd5