### PR TITLE
Refactor navbar dropdown into reusable macro

### DIFF
--- a/tests/test_navigation_dropdown.py
+++ b/tests/test_navigation_dropdown.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+import website.app as app_module
+
+app = app_module.app
+add_to_allowlist = app_module.add_to_allowlist
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    app_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    client.post('/login', data={'email': 'user@example.com', 'password': 'secret'}, follow_redirects=True)
+
+
+def test_dropdown_public():
+    client = app.test_client()
+    response = client.get('/login')
+    assert response.status_code == 200
+    assert b'Invitado' in response.data
+    assert b'Iniciar sesi' in response.data
+
+
+def test_dropdown_authenticated():
+    client = app.test_client()
+    login(client)
+    response = client.get('/generador')
+    assert response.status_code == 200
+    assert b'user@example.com' in response.data
+    assert b'Salir' in response.data

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -15,6 +15,7 @@
 <body>
   {% set is_public = request.endpoint in ['landing','index','checkout','subscribe'] %}
   {% set is_auth   = session.get('user') %}
+  {% from 'macros.html' import user_dropdown %}
 
   <header>
     <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom sticky-top">
@@ -38,54 +39,14 @@
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
             <i class="bi bi-moon" aria-hidden="true"></i>
           </button>
-          <div class="dropdown">
-            {% set avatar = session.get('avatar_url') %}
-            {% set user_email = session.get('user', 'Invitado') %}
-            <a href="#" class="d-flex align-items-center text-decoration-none" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              {% if avatar %}
-                <img src="{{ avatar }}" class="rounded-circle me-2" alt="avatar" width="32" height="32">
-              {% else %}
-                <i class="bi bi-person-circle fs-4 me-2" aria-hidden="true"></i>
-              {% endif %}
-              <span>{{ user_email }} ▾</span>
-            </a>
-            <ul class="dropdown-menu dropdown-menu-end">
-              <li><a class="dropdown-item" href="{{ url_for('configuracion') }}">Perfil</a></li>
-              <li><hr class="dropdown-divider"></li>
-              {% if is_auth %}
-                <li><a class="dropdown-item" href="{{ url_for('logout') }}">Salir</a></li>
-              {% else %}
-                <li><a class="dropdown-item" href="{{ url_for('login') }}">Iniciar sesión</a></li>
-              {% endif %}
-            </ul>
-          </div>
+          {{ user_dropdown(is_auth) }}
         </div>
         {% else %}
         <div class="d-flex ms-auto align-items-center">
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
             <i class="bi bi-moon" aria-hidden="true"></i>
           </button>
-          <div class="dropdown">
-            {% set avatar = session.get('avatar_url') %}
-            {% set user_email = session.get('user', 'Invitado') %}
-            <a href="#" class="d-flex align-items-center text-decoration-none" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              {% if avatar %}
-                <img src="{{ avatar }}" class="rounded-circle me-2" alt="avatar" width="32" height="32">
-              {% else %}
-                <i class="bi bi-person-circle fs-4 me-2" aria-hidden="true"></i>
-              {% endif %}
-              <span>{{ user_email }} ▾</span>
-            </a>
-            <ul class="dropdown-menu dropdown-menu-end">
-              <li><a class="dropdown-item" href="{{ url_for('configuracion') }}">Perfil</a></li>
-              <li><hr class="dropdown-divider"></li>
-              {% if is_auth %}
-                <li><a class="dropdown-item" href="{{ url_for('logout') }}">Salir</a></li>
-              {% else %}
-                <li><a class="dropdown-item" href="{{ url_for('login') }}">Iniciar sesión</a></li>
-              {% endif %}
-            </ul>
-          </div>
+          {{ user_dropdown(is_auth) }}
         </div>
         {% endif %}
       </div>

--- a/website/templates/macros.html
+++ b/website/templates/macros.html
@@ -1,0 +1,23 @@
+{% macro user_dropdown(is_auth) %}
+  {% set avatar = session.get('avatar_url') %}
+  {% set user_email = session.get('user', 'Invitado') %}
+  <div class="dropdown">
+    <a href="#" class="d-flex align-items-center text-decoration-none" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      {% if avatar %}
+        <img src="{{ avatar }}" class="rounded-circle me-2" alt="avatar" width="32" height="32">
+      {% else %}
+        <i class="bi bi-person-circle fs-4 me-2" aria-hidden="true"></i>
+      {% endif %}
+      <span>{{ user_email }} ▾</span>
+    </a>
+    <ul class="dropdown-menu dropdown-menu-end">
+      <li><a class="dropdown-item" href="{{ url_for('configuracion') }}">Perfil</a></li>
+      <li><hr class="dropdown-divider"></li>
+      {% if is_auth %}
+        <li><a class="dropdown-item" href="{{ url_for('logout') }}">Salir</a></li>
+      {% else %}
+        <li><a class="dropdown-item" href="{{ url_for('login') }}">Iniciar sesión</a></li>
+      {% endif %}
+    </ul>
+  </div>
+{% endmacro %}


### PR DESCRIPTION
## Summary
- factor dropdown HTML into `user_dropdown` Jinja macro
- call macro from both authenticated and public nav paths
- test dropdown rendering for guest and logged-in users

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689962e2202883278d1dd2ab8e3b4f5e