### PR TITLE
Add CSRF protection to forms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pulp==2.7.*
 psutil==5.9.5
 requests==2.31.0
 python-dotenv==1.0.0
+Flask-WTF==1.1.1

--- a/website/templates/contacto.html
+++ b/website/templates/contacto.html
@@ -1,7 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Contacto y Cotización</h1>
-<form class="mb-4">
+<form class="mb-4" method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="name" class="form-label">Nombre</label>
     <input type="text" class="form-control" id="name" placeholder="Tu nombre">

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -7,6 +7,7 @@
   </div>
 
   <form id="genForm" class="needs-validation" novalidate method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Archivo + Perfil -->
     <div class="card mb-4">
       <div class="card-body">

--- a/website/templates/login.html
+++ b/website/templates/login.html
@@ -16,6 +16,7 @@
     <div class="card auth-card p-4 shadow-soft">
       <h4 class="mb-3">Iniciar sesión</h4>
       <form method="post" action="{{ url_for('login') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="mb-3">
           <label class="form-label">Correo</label>
           <input name="email" type="email" class="form-control" required placeholder="tucorreo@ejemplo.com" value="{{ request.form.get('email','') }}">


### PR DESCRIPTION
## Summary
- Add Flask-WTF and configure `WTF_CSRF_SECRET_KEY`
- Embed CSRF tokens in HTML forms and validate them on POST
- Update tests to include CSRF token handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689962e3c6f88327bb0e384a7625c7bb