### PR TITLE
Add custom error pages and handlers

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -623,6 +623,18 @@ def paypal_create_plan():
         return jsonify({"error": str(e)}), 500
 
 
+@app.errorhandler(404)
+def not_found(error):
+    app.logger.error("404 error: %s", error)
+    return render_template("404.html"), 404
+
+
+@app.errorhandler(500)
+def internal_error(error):
+    app.logger.exception("500 error: %s", error)
+    return render_template("500.html"), 500
+
+
 @app.route('/api/paypal/create-order', methods=['POST'])
 def paypal_create_order_endpoint():
     data = request.get_json(silent=True) or {}

--- a/website/templates/404.html
+++ b/website/templates/404.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+  <h1>Página no encontrada</h1>
+  <p>La página que buscas no existe.</p>
+{% endblock %}

--- a/website/templates/500.html
+++ b/website/templates/500.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+  <h1>Error interno del servidor</h1>
+  <p>Ha ocurrido un error inesperado.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add 404 and 500 templates extending the base layout
- Register Flask error handlers for 404 and 500 to log and render the new pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689962f0cfa88327b9c25891fa8f3990