### PR TITLE
Add custom error pages

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -627,15 +627,14 @@ def paypal_create_plan():
 
 
 @app.errorhandler(404)
-def not_found(error):
-    app.logger.error("404 error: %s", error)
-    return render_template("404.html"), 404
+def not_found(e):
+    return render_template('404.html'), 404
 
 
 @app.errorhandler(500)
-def internal_error(error):
-    app.logger.exception("500 error: %s", error)
-    return render_template("500.html"), 500
+def server_error(e):
+    app.logger.exception(e)
+    return render_template('500.html'), 500
 
 
 @app.route('/api/paypal/create-order', methods=['POST'])

--- a/website/templates/404.html
+++ b/website/templates/404.html
@@ -2,4 +2,5 @@
 {% block content %}
   <h1>Página no encontrada</h1>
   <p>La página que buscas no existe.</p>
+  <a href="{{ url_for('landing') }}" class="btn btn-primary mt-3">Volver al inicio</a>
 {% endblock %}

--- a/website/templates/500.html
+++ b/website/templates/500.html
@@ -2,4 +2,5 @@
 {% block content %}
   <h1>Error interno del servidor</h1>
   <p>Ha ocurrido un error inesperado.</p>
+  <a href="{{ url_for('landing') }}" class="btn btn-primary mt-3">Volver al inicio</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add error handlers for 404 and 500 in app
- show friendly pages with link back home

## Testing
- `pytest`
- manual test via Flask test_client for 404


------
https://chatgpt.com/codex/tasks/task_e_68996bf468388327bf12b879d699f541