### PR TITLE
Add root route for core blueprint

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -33,6 +33,11 @@ def login_required(view):
 # Routes
 # ---------------------------------------------------------------------------
 
+@bp.route("/")
+def index():
+    return render_template("index.html")
+    # o: return redirect(url_for("core.login"))
+
 @bp.route("/login", methods=["GET", "POST"])
 def login():
     if request.method == "POST":


### PR DESCRIPTION
## Summary
- Add index route to core blueprint that renders `index.html`

## Testing
- `pytest`
- `curl -i http://127.0.0.1:5000/`


------
https://chatgpt.com/codex/tasks/task_e_68997bc1cfe48327b5637a80c10be1e4