### PR TITLE
Use landing page for root

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -34,9 +34,14 @@ def login_required(view):
 # ---------------------------------------------------------------------------
 
 @bp.route("/")
+def landing():
+    return render_template("landing.html")
+    # o: return redirect(url_for("core.login"))
+
+
+@bp.route("/index")
 def index():
     return render_template("index.html")
-    # o: return redirect(url_for("core.login"))
 
 @bp.route("/login", methods=["GET", "POST"])
 def login():


### PR DESCRIPTION
## Summary
- Serve landing page at site root via `landing` view
- Keep simplified homepage at `/index`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68997fac29c883278a8d8c0318f98117