### PR TITLE
Add subscribe success endpoint and tests

### DIFF
--- a/tests/test_subscribe_success.py
+++ b/tests/test_subscribe_success.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+
+app = create_app()
+
+
+def test_subscribe_success_route():
+    client = app.test_client()
+    response = client.get('/subscribe/success')
+    assert response.status_code == 200
+    assert 'Suscripción completa' in response.get_data(as_text=True)

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -84,6 +84,11 @@ def configuracion():
     return render_template("configuracion.html")
 
 
+@bp.route("/subscribe/success")
+def subscribe_success():
+    return render_template("subscribe_success.html")
+
+
 # ---------------------------------------------------------------------------
 # Error handlers
 # ---------------------------------------------------------------------------

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -71,7 +71,7 @@
           body: JSON.stringify({ subscription_id: sub })
         });
         if (!res.ok) throw new Error(await res.text());
-        window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(sub);
+        window.location.href = "{{ url_for('core.subscribe_success') }}?sub=" + encodeURIComponent(sub);
       } catch (err) {
         console.error(err);
         alert('Error con PayPal al activar.');

--- a/website/templates/subscribe_success.html
+++ b/website/templates/subscribe_success.html
@@ -11,6 +11,6 @@
   {% else %}
     <a href="{{ url_for('core.login') }}" class="btn btn-primary mt-3">Iniciar sesión</a>
   {% endif %}
-  <p class="mt-4"><a href="{{ url_for('landing') }}">Volver al inicio</a></p>
+  <p class="mt-4"><a href="{{ url_for('core.landing') }}">Volver al inicio</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `/subscribe/success` route rendering a confirmation template
- update subscription checkout to redirect to `core.subscribe_success`
- add regression test for subscription success page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e653eb5c8327a8015632d43b4fcc