### PR TITLE
Add subscription success route and tests

### DIFF
--- a/tests/test_subscribe_success_route.py
+++ b/tests/test_subscribe_success_route.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+from contextlib import contextmanager
+
+import pytest
+from flask import template_rendered
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+
+
+@contextmanager
+def captured_templates(app):
+    recorded = []
+    def record(sender, template, context, **extra):
+        recorded.append(template)
+    template_rendered.connect(record, app)
+    try:
+        yield recorded
+    finally:
+        template_rendered.disconnect(record, app)
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def test_subscribe_success_route():
+    client = app.test_client()
+    with captured_templates(app) as templates:
+        response = client.get('/subscribe/success')
+    assert response.status_code == 200
+    assert templates and templates[0].name == 'subscribe_success.html'

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -89,6 +89,11 @@ def contacto():
     return render_template("contacto.html")
 
 
+@bp.route("/subscribe/success")
+def subscribe_success():
+    return render_template("subscribe_success.html")
+
+
 # ---------------------------------------------------------------------------
 # Error handlers
 # ---------------------------------------------------------------------------

--- a/website/templates/subscribe.html
+++ b/website/templates/subscribe.html
@@ -71,7 +71,7 @@
           body: JSON.stringify({ subscription_id: sub })
         });
         if (!res.ok) throw new Error(await res.text());
-        window.location.href = "{{ url_for('subscribe_success') }}?sub=" + encodeURIComponent(sub);
+        window.location.href = "{{ url_for('core.subscribe_success') }}?sub=" + encodeURIComponent(sub);
       } catch (err) {
         console.error(err);
         alert('Error con PayPal al activar.');

--- a/website/templates/subscribe_success.html
+++ b/website/templates/subscribe_success.html
@@ -11,6 +11,6 @@
   {% else %}
     <a href="{{ url_for('core.login') }}" class="btn btn-primary mt-3">Iniciar sesión</a>
   {% endif %}
-  <p class="mt-4"><a href="{{ url_for('landing') }}">Volver al inicio</a></p>
+  <p class="mt-4"><a href="{{ url_for('core.landing') }}">Volver al inicio</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add `/subscribe/success` route to render confirmation page
- Redirect PayPal subscription flow to new `core.subscribe_success` endpoint
- Cover subscription success page with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899ed6b59bc8327bb12f660ffa3c6cf