### PR TITLE
Add subscription route and tests

### DIFF
--- a/tests/test_subscribe_route.py
+++ b/tests/test_subscribe_route.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+from contextlib import contextmanager
+
+import pytest
+from flask import template_rendered
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+
+
+@contextmanager
+def captured_templates(app):
+    recorded = []
+    def record(sender, template, context, **extra):
+        recorded.append(template)
+    template_rendered.connect(record, app)
+    try:
+        yield recorded
+    finally:
+        template_rendered.disconnect(record, app)
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def test_subscribe_route():
+    client = app.test_client()
+    with captured_templates(app) as templates:
+        response = client.get('/subscribe', query_string={'plan': 'starter'})
+    assert response.status_code == 200
+    assert templates and templates[0].name == 'subscribe.html'

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -1,3 +1,4 @@
+import os
 from functools import wraps
 from flask import (
     Blueprint,
@@ -87,6 +88,30 @@ def configuracion():
 @bp.route("/contacto")
 def contacto():
     return render_template("contacto.html")
+
+
+@bp.route("/subscribe")
+def subscribe():
+    plan = request.args.get("plan", "starter")
+    plans = {
+        "starter": {
+            "paypal_plan_id": os.getenv("PAYPAL_PLAN_ID_STARTER"),
+            "amount": float(os.getenv("STARTER_AMOUNT", "0")),
+        },
+        "pro": {
+            "paypal_plan_id": os.getenv("PAYPAL_PLAN_ID_PRO"),
+            "amount": float(os.getenv("PRO_AMOUNT", "0")),
+        },
+    }
+    data = plans.get(plan, plans["starter"])
+    return render_template(
+        "subscribe.html",
+        paypal_plan_id=data["paypal_plan_id"],
+        paypal_client_id=os.getenv("PAYPAL_CLIENT_ID"),
+        paypal_env=os.getenv("PAYPAL_ENV", "sandbox"),
+        amount=data["amount"],
+        tier=plan if plan in plans else "starter",
+    )
 
 
 @bp.route("/subscribe/success")

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
 <body>
-  {% set is_public = request.endpoint in ['landing','index','checkout','subscribe'] %}
+    {% set is_public = request.endpoint in ['core.landing','core.index','core.checkout','core.subscribe'] %}
   {% set is_auth   = session.get('user') %}
   {% from 'macros.html' import user_dropdown %}
 

--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -294,7 +294,7 @@
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Exportar a Excel</li>
                 <li><i class="bi bi-dash text-muted me-1" aria-hidden="true"></i><span class="visually-hidden">No incluido: </span>JEAN personalizado</li>
             </ul>
-            <a href="{{ url_for('subscribe', plan='starter') }}" class="btn btn-outline-secondary w-100">Ir al checkout</a>
+            <a href="{{ url_for('core.subscribe', plan='starter') }}" class="btn btn-outline-secondary w-100">Ir al checkout</a>
           </div>
         </div>
       </div>
@@ -310,7 +310,7 @@
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>JEAN personalizado</li>
                 <li><i class="bi bi-check2 check me-1" aria-hidden="true"></i><span class="visually-hidden">Incluido: </span>Métricas y heatmaps</li>
             </ul>
-            <a href="{{ url_for('subscribe', plan='pro') }}" class="btn btn-primary w-100">Ir al checkout</a>
+            <a href="{{ url_for('core.subscribe', plan='pro') }}" class="btn btn-primary w-100">Ir al checkout</a>
           </div>
         </div>
       </div>
@@ -363,7 +363,7 @@
   <div class="container-xxl text-center">
     <h3 class="fw-bold text-ink mb-3">¿Listo para optimizar tus turnos?</h3>
     <p class="text-muted-adv mb-4">Suscríbete para comenzar. Si ya tienes cuenta, inicia sesión.</p>
-    <a href="{{ url_for('subscribe') }}" class="btn btn-brand btn-lg px-4">Suscribirme</a>
+    <a href="{{ url_for('core.subscribe') }}" class="btn btn-brand btn-lg px-4">Suscribirme</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Implement `/subscribe` route that loads PayPal plan details and renders the subscription page
- Update templates to reference `core.subscribe` and mark public endpoints
- Add unit test for subscription view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f2b564d48327b7061e152800ddd7