### PR TITLE
Pass plan query parameter for subscribe CTA

### DIFF
--- a/website/templates/landing.html
+++ b/website/templates/landing.html
@@ -363,7 +363,7 @@
   <div class="container-xxl text-center">
     <h3 class="fw-bold text-ink mb-3">¿Listo para optimizar tus turnos?</h3>
     <p class="text-muted-adv mb-4">Suscríbete para comenzar. Si ya tienes cuenta, inicia sesión.</p>
-    <a href="{{ url_for('core.subscribe') }}" class="btn btn-brand btn-lg px-4">Suscribirme</a>
+    <a href="{{ url_for('core.subscribe', plan='starter') }}" class="btn btn-brand btn-lg px-4">Suscribirme</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Ensure landing CTA link uses `url_for('core.subscribe', plan='starter')` so plan is sent as a query string

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab92b859c832797a952561b1de2cc