### PR TITLE
Add action to generador form

### DIFF
--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -6,7 +6,7 @@
     <span class="text-muted small">Replica mejorada del app1 (Streamlit)</span>
   </div>
 
-  <form id="genForm" class="needs-validation" novalidate method="post" enctype="multipart/form-data">
+  <form id="genForm" class="needs-validation" novalidate action="{{ url_for('core.generador') }}" method="post" enctype="multipart/form-data">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Archivo + Perfil -->
     <div class="card mb-4">


### PR DESCRIPTION
## Summary
- specify core.generador route in generador form and keep CSRF token

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac102d96883278520908a4a9526df