### PR TITLE
Persist generated results and render from session

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import types
+from io import BytesIO
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_resultados_redirects_without_result():
+    client = app.test_client()
+    login(client)
+    response = client.get('/resultados')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/generador')
+
+
+def test_generador_stores_and_renders_result():
+    client = app.test_client()
+    login(client)
+    sys.modules['website.scheduler'].run_complete_optimization = lambda *a, **k: {'metrics': {}}
+    token = _csrf_token(client, '/generador')
+    data = {'excel': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}
+    response = client.post('/generador', data=data, content_type='multipart/form-data', follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/resultados')
+    result_page = client.get('/resultados')
+    assert result_page.status_code == 200
+    assert b'Resultados' in result_page.data
+    # After rendering once, the result should be cleared
+    response_again = client.get('/resultados')
+    assert response_again.status_code == 302
+    assert response_again.headers['Location'].endswith('/generador')

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -104,9 +104,12 @@ def generador():
 
         result = run_complete_optimization(excel_file, config=config)
 
-        if request.accept_mimetypes["application/json"] >= request.accept_mimetypes["text/html"]:
+        if request.accept_mimetypes["application/json"] > request.accept_mimetypes["text/html"]:
             return jsonify(result)
-        return render_template("resultados.html", resultado=result)
+
+        # Persist a summary of the result so it can be retrieved later
+        session["resultado"] = result
+        return redirect(url_for("core.resultados"))
 
     return render_template("generador.html")
 
@@ -114,7 +117,12 @@ def generador():
 @bp.route("/resultados")
 @login_required
 def resultados():
-    return render_template("resultados.html")
+    resultado = session.get("resultado")
+    if not resultado:
+        return redirect(url_for("core.generador"))
+    # Optional: clear stored result to avoid stale data
+    session.pop("resultado", None)
+    return render_template("resultados.html", resultado=resultado)
 
 
 @bp.route("/configuracion")


### PR DESCRIPTION
## Summary
- Store generated optimization results in `session['resultado']` and redirect to the results page
- Update `/resultados` route to load results from session and clear stale data
- Add tests covering result persistence and redirect behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ac7b82e748327933d75206ef2227b