### PR TITLE
Persist optimization result to temporary storage

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -8,7 +8,6 @@ from io import BytesIO
 from itertools import combinations, permutations
 
 from flask import session
-import base64
 import tempfile
 
 import numpy as np
@@ -1863,11 +1862,12 @@ def run_complete_optimization(file_stream, config=None):
         else:
             maps = generate_all_heatmaps(demand_matrix)
         for key, fig in maps.items():
-            buf = BytesIO()
-            fig.savefig(buf, format="png", bbox_inches="tight")
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+            fig.savefig(tmp.name, format="png", bbox_inches="tight")
             plt.close(fig)
-            buf.seek(0)
-            heatmaps[key] = base64.b64encode(buf.getvalue()).decode("utf-8")
+            tmp.flush()
+            tmp.close()
+            heatmaps[key] = tmp.name
 
         print("\U0001F4E4 [SCHEDULER] Preparando resultados...")
 


### PR DESCRIPTION
## Summary
- Store optimization output in a temporary JSON file and keep only the file path in session
- Load result file in results view, encode heatmap images from temporary files, and clean up all temporary data
- Save scheduler heatmaps to temporary images instead of base64 strings to reduce stored data size

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b7a6d8160832795f6bd3f62a0a570