### PR TITLE
feat: make heatmap generation optional

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -104,7 +104,11 @@ def generador():
 
         from ..scheduler import run_complete_optimization
 
-        result = run_complete_optimization(excel_file, config=config)
+        result = run_complete_optimization(
+            excel_file,
+            config=config,
+            generate_charts=config.get("generate_charts", False),
+        )
 
         if request.accept_mimetypes["application/json"] > request.accept_mimetypes["text/html"]:
             return jsonify(result)


### PR DESCRIPTION
## Summary
- Add `generate_heatmap_files` helper that saves charts and closes figures to free memory
- Make `run_complete_optimization` generate heatmaps only when `generate_charts` is requested and return demand matrix for later chart requests
- Allow `/generador` route to forward the `generate_charts` flag to the scheduler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8bea36fc83278f4ce2e961681771