### PR TITLE
Stream schedule export to Excel and CSV

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -51,7 +51,7 @@ def test_generador_stores_and_renders_result():
     client = app.test_client()
     login(client)
     sys.modules['website.scheduler'].run_complete_optimization = (
-        lambda *a, **k: ({'metrics': {}}, b'')
+        lambda *a, **k: ({'metrics': {}}, b'', b'')
     )
     token = _csrf_token(client, '/generador')
     data = {'excel': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -104,7 +104,7 @@ def generador():
 
         from ..scheduler import run_complete_optimization
 
-        result, excel_bytes = run_complete_optimization(excel_file, config=config)
+        result, excel_bytes, csv_bytes = run_complete_optimization(excel_file, config=config)
 
         job_id = uuid.uuid4().hex
 
@@ -116,6 +116,11 @@ def generador():
             xlsx_path = os.path.join("/tmp", f"{job_id}.xlsx")
             with open(xlsx_path, "wb") as f:
                 f.write(excel_bytes)
+
+        if csv_bytes:
+            csv_path = os.path.join("/tmp", f"{job_id}.csv")
+            with open(csv_path, "wb") as f:
+                f.write(csv_bytes)
 
         session["job_id"] = job_id
 
@@ -157,6 +162,11 @@ def resultados():
 
     try:
         os.remove(os.path.join("/tmp", f"{job_id}.xlsx"))
+    except OSError:
+        pass
+
+    try:
+        os.remove(os.path.join("/tmp", f"{job_id}.csv"))
     except OSError:
         pass
 


### PR DESCRIPTION
## Summary
- Rewrite schedule export to stream rows using write-only openpyxl workbook and csv writer
- Capture both Excel and CSV bytes in optimization pipeline
- Persist generated CSVs alongside XLSX results and clean them up

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b919529588327ae69021c50b37ec9