### PR TITLE
Serve heatmaps from temporary files

### DIFF
--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -70,7 +70,7 @@
     <div class="col-md-6">
       <div class="card">
         <div class="card-header">Demanda requerida</div>
-        <img class="card-img-bottom" alt="Demanda" src="data:image/png;base64,{{ resultado.heatmaps.demand }}">
+        <img class="card-img-bottom" alt="Demanda" src="{{ resultado.heatmaps.demand }}">
       </div>
     </div>
     {% endif %}
@@ -79,7 +79,7 @@
     <div class="col-md-6">
       <div class="card">
         <div class="card-header">Cobertura asignada</div>
-        <img class="card-img-bottom" alt="Cobertura" src="data:image/png;base64,{{ resultado.heatmaps.coverage }}">
+        <img class="card-img-bottom" alt="Cobertura" src="{{ resultado.heatmaps.coverage }}">
       </div>
     </div>
     {% endif %}
@@ -88,7 +88,7 @@
     <div class="col-12">
       <div class="card">
         <div class="card-header">Diferencias (Cobertura - Demanda)</div>
-        <img class="card-img-bottom" alt="Diferencias" src="data:image/png;base64,{{ resultado.heatmaps.difference }}">
+        <img class="card-img-bottom" alt="Diferencias" src="{{ resultado.heatmaps.difference }}">
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- Save optimizer heatmaps under a job-specific directory in `/tmp`
- Return URLs for heatmaps and serve them through a new endpoint that deletes files after download
- Update results template to load images via URLs instead of embedded base64

## Testing
- `pytest -q`
- `git merge --no-ff --no-commit main`


------
https://chatgpt.com/codex/tasks/task_e_689b9198b2d88327922e24bc656fdcaa