### PR TITLE
Add chart generation toggle to generator

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -84,7 +84,7 @@ def generador():
 
         config = {}
         for key, value in request.form.items():
-            if key == "csrf_token":
+            if key in {"csrf_token", "generate_charts"}:
                 continue
             low = value.lower()
             if low in {"on", "true", "1"}:
@@ -104,9 +104,15 @@ def generador():
             except Exception:
                 pass
 
+        generate_charts = (
+            request.form.get("generate_charts", "false").lower() in {"on", "true", "1"}
+        )
+
         from ..scheduler import run_complete_optimization
 
-        result, excel_bytes, csv_bytes = run_complete_optimization(excel_file, config=config)
+        result, excel_bytes, csv_bytes = run_complete_optimization(
+            excel_file, config=config, generate_charts=generate_charts
+        )
 
         job_id = uuid.uuid4().hex
 

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -2,19 +2,27 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('genForm');
   const spinner = document.getElementById('spinner');
   const slowMsg = document.getElementById('slowMsg');
-  const btn = document.getElementById('btnSubmit');
+  const btnExcel = document.getElementById('btnExcel');
+  const btnCharts = document.getElementById('btnCharts');
+  let generateCharts = false;
 
-  if (!form || !spinner || !slowMsg || !btn) return;
+  if (!form || !spinner || !slowMsg || !btnExcel || !btnCharts) return;
 
   form.addEventListener('submit', (e) => {
+    generateCharts = e.submitter === btnCharts;
     if (!form.checkValidity()) {
       e.preventDefault();
       e.stopPropagation();
       form.classList.add('was-validated');
       return;
     }
-    btn.disabled = true;
+    btnExcel.disabled = true;
+    btnCharts.disabled = true;
     spinner.classList.remove('d-none');
     setTimeout(() => slowMsg.classList.remove('d-none'), 10000);
+  });
+
+  form.addEventListener('formdata', (e) => {
+    e.formData.append('generate_charts', generateCharts ? 'true' : 'false');
   });
 });

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -181,8 +181,11 @@
     </div><!-- /accordion -->
 
     <div class="d-flex align-items-center gap-3">
-      <button type="submit" class="btn btn-primary px-4" id="btnSubmit">
-        Generar Horarios
+      <button type="submit" class="btn btn-primary px-4" id="btnExcel">
+        Generar Excel
+      </button>
+      <button type="submit" class="btn btn-secondary px-4" id="btnCharts">
+        Generar Gráficas
       </button>
       <div class="spinner-border text-primary d-none" id="spinner" role="status" aria-hidden="true"></div>
       <div class="text-warning-emphasis d-none" id="slowMsg">La generación está tardando más de lo esperado…</div>

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -65,8 +65,9 @@
   {% endif %}
 
   <!-- Heatmaps -->
+  {% if resultado and resultado.heatmaps %}
   <div class="row g-4 mb-4">
-    {% if resultado and resultado.heatmaps and resultado.heatmaps.demand %}
+    {% if resultado.heatmaps.demand %}
     <div class="col-md-6">
       <div class="card">
         <div class="card-header">Demanda requerida</div>
@@ -75,7 +76,7 @@
     </div>
     {% endif %}
 
-    {% if resultado and resultado.heatmaps and resultado.heatmaps.coverage %}
+    {% if resultado.heatmaps.coverage %}
     <div class="col-md-6">
       <div class="card">
         <div class="card-header">Cobertura asignada</div>
@@ -84,7 +85,7 @@
     </div>
     {% endif %}
 
-    {% if resultado and resultado.heatmaps and resultado.heatmaps.difference %}
+    {% if resultado.heatmaps.difference %}
     <div class="col-12">
       <div class="card">
         <div class="card-header">Diferencias (Cobertura - Demanda)</div>
@@ -93,6 +94,7 @@
     </div>
     {% endif %}
   </div>
+  {% endif %}
 
   <!-- Asignaciones -->
   {% if resultado and resultado.assignments %}


### PR DESCRIPTION
## Summary
- Add separate 'Generar Excel' and 'Generar Gráficas' buttons in generator form
- Attach generate_charts flag in frontend and pass through backend to scheduler
- Show heatmaps in results template only when available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689baa8ad41483279927b6bea8643518