### PR TITLE
Use heaps for pattern selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ memory and caps generation automatically.  Patterns are generated and solved
 in batches (2000 patterns by default), sorted by a quick heuristic score, so even 50&nbsp;000+ combinations
 can be handled without exhausting RAM.  `generate_shifts_coverage_optimized()`
 still honours the `batch_size` option to emit patterns in smaller chunks.
+The configuration also exposes a `K` parameter that bounds how many of the
+best scoring patterns are kept in memory.  A heap is used internally to retain
+only the top `K` entries, discarding lower scored ones to further reduce the
+memory footprint.
 
 ## Memory-aware Generation
 


### PR DESCRIPTION
## Summary
- Limit custom JEAN pattern generation using a heap of top-K scored entries
- Process optimization chunks with a score-ordered heap instead of sorting lists
- Expose configurable K parameter and document heap-based selection

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689baa91b80083279d3f856c3062a91e