### PR TITLE
Add CSV download route and link

### DIFF
--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -3,9 +3,14 @@
 
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h2 class="mb-0 fw-bold">Resultados</h2>
-    {% if resultado and resultado.download_url %}
-      <a class="btn btn-success" href="{{ resultado.download_url }}">Descargar Excel</a>
-    {% endif %}
+    <div class="d-flex gap-2">
+      {% if resultado and resultado.csv_url %}
+        <a class="btn btn-secondary" href="{{ resultado.csv_url }}">Descargar CSV</a>
+      {% endif %}
+      {% if resultado and resultado.download_url %}
+        <a class="btn btn-success" href="{{ resultado.download_url }}">Descargar Excel</a>
+      {% endif %}
+    </div>
   </div>
 
   <!-- KPIs -->


### PR DESCRIPTION
## Summary
- Add CSV download route that sends temporary file and deletes it afterwards
- Expose CSV download URL from generator and show download button on results page
- Remove early CSV cleanup so files delete only when downloaded

## Testing
- `pytest` *(fails: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_689bb33281608327928eb7a2fda0e5f1