### PR TITLE
Defer report generation to separate routes

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -50,8 +50,8 @@ def test_resultados_redirects_without_result():
 def test_generador_stores_and_renders_result():
     client = app.test_client()
     login(client)
-    sys.modules['website.scheduler'].run_complete_optimization = (
-        lambda *a, **k: ({'metrics': {}}, b'', b'')
+    sys.modules['website.scheduler'].run_optimization = (
+        lambda *a, **k: {'metrics': {}, 'assignments': {}}
     )
     token = _csrf_token(client, '/generador')
     data = {'excel': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}
@@ -61,7 +61,6 @@ def test_generador_stores_and_renders_result():
     result_page = client.get('/resultados')
     assert result_page.status_code == 200
     assert b'Resultados' in result_page.data
-    # After rendering once, the result should be cleared
+    # Result should remain available across requests
     response_again = client.get('/resultados')
-    assert response_again.status_code == 302
-    assert response_again.headers['Location'].endswith('/generador')
+    assert response_again.status_code == 200

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -1,6 +1,7 @@
 import os
 import json
 import uuid
+from io import BytesIO
 from functools import wraps
 from flask import (
     Blueprint,
@@ -104,53 +105,16 @@ def generador():
             except Exception:
                 pass
 
-        generate_charts = (
-            request.form.get("generate_charts", "false").lower() in {"on", "true", "1"}
-        )
+        from ..scheduler import run_optimization
 
-        from ..scheduler import run_complete_optimization
-
-        result, excel_bytes, csv_bytes = run_complete_optimization(
-            excel_file, config=config, generate_charts=generate_charts
-        )
-
+        result = run_optimization(excel_file, config=config)
         job_id = uuid.uuid4().hex
-
-        heatmaps = result.get("heatmaps", {})
-        if heatmaps:
-            heatmap_dir = os.path.join("/tmp", job_id)
-            os.makedirs(heatmap_dir, exist_ok=True)
-            for key, path in list(heatmaps.items()):
-                try:
-                    new_name = f"{key}.png"
-                    dest = os.path.join(heatmap_dir, new_name)
-                    os.replace(path, dest)
-                    heatmaps[key] = new_name
-                except OSError:
-                    heatmaps[key] = None
-            result["heatmaps"] = heatmaps
-
-        if excel_bytes:
-            xlsx_path = os.path.join("/tmp", f"{job_id}.xlsx")
-            with open(xlsx_path, "wb") as f:
-                f.write(excel_bytes)
-            result["download_url"] = url_for("core.download_excel", job_id=job_id)
-
-        if csv_bytes:
-            csv_path = os.path.join("/tmp", f"{job_id}.csv")
-            with open(csv_path, "wb") as f:
-                f.write(csv_bytes)
-            result["csv_url"] = url_for("core.download_csv", job_id=job_id)
-
         json_path = os.path.join("/tmp", f"{job_id}.json")
         with open(json_path, "w", encoding="utf-8") as f:
             json.dump(result, f)
-
         session["job_id"] = job_id
-
         if request.accept_mimetypes["application/json"] > request.accept_mimetypes["text/html"]:
-            return jsonify({"job_id": job_id, **result})
-
+            return jsonify({"job_id": job_id})
         return redirect(url_for("core.resultados"))
 
     return render_template("generador.html")
@@ -170,21 +134,7 @@ def resultados():
     with open(json_path) as f:
         resultado = json.load(f)
 
-    heatmaps = resultado.get("heatmaps", {})
-    for key, fname in list(heatmaps.items()):
-        if fname:
-            heatmaps[key] = url_for("core.heatmap", job_id=job_id, filename=fname)
-        else:
-            heatmaps[key] = None
-
-    try:
-        os.remove(json_path)
-    except OSError:
-        pass
-
-    session.pop("job_id", None)
-
-    return render_template("resultados.html", resultado=resultado)
+    return render_template("resultados.html", resultado=resultado, job_id=job_id)
 
 
 @bp.route("/download/<job_id>")
@@ -240,6 +190,46 @@ def heatmap(job_id, filename):
         return response
 
     return send_file(path, mimetype="image/png")
+
+
+@bp.route("/generate_excel/<job_id>")
+@login_required
+def generate_excel(job_id):
+    json_path = os.path.join("/tmp", f"{job_id}.json")
+    if not os.path.exists(json_path):
+        abort(404)
+    with open(json_path) as f:
+        data = json.load(f)
+    from ..scheduler import generate_excel as gen_excel
+    excel_bytes = gen_excel(data)
+    if not excel_bytes:
+        abort(404)
+    return send_file(
+        BytesIO(excel_bytes),
+        as_attachment=True,
+        download_name="resultado.xlsx",
+        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+
+@bp.route("/generate_charts/<job_id>")
+@login_required
+def generate_charts(job_id):
+    json_path = os.path.join("/tmp", f"{job_id}.json")
+    if not os.path.exists(json_path):
+        abort(404)
+    with open(json_path) as f:
+        data = json.load(f)
+    from ..scheduler import generate_heatmaps
+    zip_bytes = generate_heatmaps(data)
+    if not zip_bytes:
+        abort(404)
+    return send_file(
+        BytesIO(zip_bytes),
+        as_attachment=True,
+        download_name="heatmaps.zip",
+        mimetype="application/zip",
+    )
 
 
 

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -10,6 +10,7 @@ import heapq
 
 import tempfile
 import csv
+from zipfile import ZipFile
 
 import numpy as np
 try:
@@ -2041,3 +2042,50 @@ def run_complete_optimization(file_stream, config=None, generate_charts=False):
 
     except Exception as e:
         print(f"\u274C [SCHEDULER] ERROR CRÍTICO: {str(e)}")
+
+
+def run_optimization(file_stream, config=None):
+    """Run optimization without generating files or charts."""
+    result, _, _ = run_complete_optimization(
+        file_stream, config=config, generate_charts=False
+    )
+    return result
+
+
+def generate_excel(data):
+    """Create a simple Excel file summarising assignments."""
+    assignments = data.get("assignments", {})
+    if not assignments:
+        return None
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Turnos_Asignados"
+    ws.append(["Turno", "Agentes"])
+    for shift, count in assignments.items():
+        ws.append([shift, count])
+    bio = BytesIO()
+    wb.save(bio)
+    return bio.getvalue()
+
+
+def generate_heatmaps(data):
+    """Generate heatmaps from stored metrics and return a ZIP archive."""
+    metrics = data.get("metrics", {})
+    coverage = metrics.get("total_coverage")
+    diff = metrics.get("diff_matrix")
+    if coverage is None:
+        return None
+    coverage = np.array(coverage)
+    diff = np.array(diff) if diff is not None else None
+    demand = coverage - diff if diff is not None else coverage
+    maps = generate_all_heatmaps(demand, coverage, diff)
+    bio = BytesIO()
+    with ZipFile(bio, "w") as zf:
+        for key, fig in maps.items():
+            buf = BytesIO()
+            fig.savefig(buf, format="png", bbox_inches="tight")
+            plt.close(fig)
+            zf.writestr(f"{key}.png", buf.getvalue())
+    return bio.getvalue()

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -4,11 +4,9 @@
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h2 class="mb-0 fw-bold">Resultados</h2>
     <div class="d-flex gap-2">
-      {% if resultado and resultado.csv_url %}
-        <a class="btn btn-secondary" href="{{ resultado.csv_url }}">Descargar CSV</a>
-      {% endif %}
-      {% if resultado and resultado.download_url %}
-        <a class="btn btn-success" href="{{ resultado.download_url }}">Descargar Excel</a>
+      {% if job_id %}
+        <a class="btn btn-success" href="{{ url_for('core.generate_excel', job_id=job_id) }}">Generar Excel</a>
+        <a class="btn btn-secondary" href="{{ url_for('core.generate_charts', job_id=job_id) }}">Generar Gráficas</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Run optimization without generating heavy artifacts and store minimal job data
- Add on-demand routes to create Excel summaries and heatmap archives
- Expose new generation actions on the results page and adjust tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bb6d1ffb083278ac4af43da4754af