### PR TITLE
Defers optimization exports to on-demand routes

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -50,8 +50,8 @@ def test_resultados_redirects_without_result():
 def test_generador_stores_and_renders_result():
     client = app.test_client()
     login(client)
-    sys.modules['website.scheduler'].run_complete_optimization = (
-        lambda *a, **k: ({'metrics': {}}, b'', b'')
+    sys.modules['website.scheduler'].run_optimization = (
+        lambda *a, **k: ({'metrics': {}}, {})
     )
     token = _csrf_token(client, '/generador')
     data = {'excel': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}


### PR DESCRIPTION
## Summary
- Separate optimization from export by adding `run_optimization`, `export_excel`, and `generate_charts`
- Defer Excel/CSV/heatmap generation to new API routes and add timing metrics
- Update tests to use the new optimization entry point

## Testing
- `pytest`
- `python - <<'PY'
import pandas as pd
from io import BytesIO
from website.scheduler import run_optimization
rows = [{'Día':1,'Horario':'08:00','Suma de Agentes Requeridos Erlang':5}, {'Día':1,'Horario':'09:00','Suma de Agentes Requeridos Erlang':3}, {'Día':2,'Horario':'10:00','Suma de Agentes Requeridos Erlang':4}]
df = pd.DataFrame(rows)
excel_io = BytesIO(); df.to_excel(excel_io, index=False); excel_io.seek(0)
result, context = run_optimization(excel_io)
print('Summary:', result['metrics']); print('Timing:', result['timing'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_689bb6da30e88327817b995492a129f6