### PR TITLE
Decouple export logic from scheduler

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -201,7 +201,9 @@ def generate_excel(job_id):
     with open(json_path) as f:
         data = json.load(f)
     from ..scheduler import generate_excel as gen_excel
-    excel_bytes = gen_excel(data)
+    assignments = data.get("assignments", {})
+    patterns = data.get("patterns", {})
+    excel_bytes, _ = gen_excel(assignments, patterns)
     if not excel_bytes:
         abort(404)
     return send_file(
@@ -221,7 +223,9 @@ def generate_charts(job_id):
     with open(json_path) as f:
         data = json.load(f)
     from ..scheduler import generate_heatmaps
-    zip_bytes = generate_heatmaps(data)
+    demand_matrix = data.get("demand_matrix")
+    metrics = data.get("metrics", {})
+    zip_bytes = generate_heatmaps(demand_matrix, metrics)
     if not zip_bytes:
         abort(404)
     return send_file(


### PR DESCRIPTION
## Summary
- streamline run_complete_optimization to only solve and compute metrics
- add generate_excel and generate_heatmaps helpers
- update routes to call helpers when exports are requested

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bbb6a09ac832796431f3d9c671caa