### PR TITLE
Remove redundant run_optimization wrapper

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -50,8 +50,8 @@ def test_resultados_redirects_without_result():
 def test_generador_stores_and_renders_result():
     client = app.test_client()
     login(client)
-    sys.modules['website.scheduler'].run_optimization = (
-        lambda *a, **k: {'metrics': {}, 'assignments': {}}
+    sys.modules['website.scheduler'].run_complete_optimization = (
+        lambda *a, **k: ({'metrics': {}, 'assignments': {}}, None, None)
     )
     token = _csrf_token(client, '/generador')
     data = {'excel': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -105,9 +105,11 @@ def generador():
             except Exception:
                 pass
 
-        from ..scheduler import run_optimization
+        from ..scheduler import run_complete_optimization
 
-        result = run_optimization(excel_file, config=config)
+        result, _, _ = run_complete_optimization(
+            excel_file, config=config, export_excel=False, generate_charts=False
+        )
         job_id = uuid.uuid4().hex
         json_path = os.path.join("/tmp", f"{job_id}.json")
         with open(json_path, "w", encoding="utf-8") as f:

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -2058,14 +2058,6 @@ def run_complete_optimization(
         print(f"\u274C [SCHEDULER] ERROR CRÍTICO: {str(e)}")
 
 
-def run_optimization(file_stream, config=None):
-    """Run optimization without generating files or charts."""
-    result, _, _ = run_complete_optimization(
-        file_stream, config=config, generate_charts=False
-    )
-    return result
-
-
 def generate_excel(data):
     """Create a simple Excel file summarising assignments."""
     assignments = data.get("assignments", {})


### PR DESCRIPTION
## Summary
- eliminate wrapper `run_optimization` so only the core optimizer remains
- update generator route to invoke `run_complete_optimization` and skip exports by default
- adjust tests to stub `run_complete_optimization`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bbb6d299883279f7b0ae78a0aea81