### PR TITLE
Refactor scheduler entry point

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -50,7 +50,7 @@ def test_resultados_redirects_without_result():
 def test_generador_stores_and_renders_result():
     client = app.test_client()
     login(client)
-    sys.modules['website.scheduler'].run_optimization = (
+    sys.modules['website.scheduler'].run_complete_optimization = (
         lambda *a, **k: {'metrics': {}, 'assignments': {}}
     )
     token = _csrf_token(client, '/generador')

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -105,9 +105,9 @@ def generador():
             except Exception:
                 pass
 
-        from ..scheduler import run_optimization
+        from ..scheduler import run_complete_optimization
 
-        result = run_optimization(excel_file, config=config)
+        result = run_complete_optimization(excel_file, config=config)
         job_id = uuid.uuid4().hex
         json_path = os.path.join("/tmp", f"{job_id}.json")
         with open(json_path, "w", encoding="utf-8") as f:

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -1995,11 +1995,6 @@ def run_complete_optimization(file_stream, config=None):
     }
 
 
-def run_optimization(file_stream, config=None):
-    """Backward-compatible alias for ``run_complete_optimization``."""
-    return run_complete_optimization(file_stream, config=config)
-
-
 def generate_excel(assignments, patterns):
     """Create Excel and CSV schedules from precomputed data."""
 


### PR DESCRIPTION
## Summary
- remove `run_optimization` alias from `website.scheduler`
- call `run_complete_optimization` directly in the core blueprint
- update tests to mock `run_complete_optimization`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bc0112d1883278b0b5f0cc2c5438f