### PR TITLE
Consolidate schedule generation into single button

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -85,7 +85,7 @@ def generador():
 
         config = {}
         for key, value in request.form.items():
-            if key in {"csrf_token", "generate_charts"}:
+            if key == "csrf_token":
                 continue
             low = value.lower()
             if low in {"on", "true", "1"}:

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -2,27 +2,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('genForm');
   const spinner = document.getElementById('spinner');
   const slowMsg = document.getElementById('slowMsg');
-  const btnExcel = document.getElementById('btnExcel');
-  const btnCharts = document.getElementById('btnCharts');
-  let generateCharts = false;
+  const btnGenerar = document.getElementById('btnGenerar');
 
-  if (!form || !spinner || !slowMsg || !btnExcel || !btnCharts) return;
+  if (!form || !spinner || !slowMsg || !btnGenerar) return;
 
   form.addEventListener('submit', (e) => {
-    generateCharts = e.submitter === btnCharts;
     if (!form.checkValidity()) {
       e.preventDefault();
       e.stopPropagation();
       form.classList.add('was-validated');
       return;
     }
-    btnExcel.disabled = true;
-    btnCharts.disabled = true;
+    btnGenerar.disabled = true;
     spinner.classList.remove('d-none');
     setTimeout(() => slowMsg.classList.remove('d-none'), 10000);
-  });
-
-  form.addEventListener('formdata', (e) => {
-    e.formData.append('generate_charts', generateCharts ? 'true' : 'false');
   });
 });

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -181,11 +181,8 @@
     </div><!-- /accordion -->
 
     <div class="d-flex align-items-center gap-3">
-      <button type="submit" class="btn btn-primary px-4" id="btnExcel">
-        Generar Excel
-      </button>
-      <button type="submit" class="btn btn-secondary px-4" id="btnCharts">
-        Generar Gráficas
+      <button type="submit" class="btn btn-primary px-4" id="btnGenerar">
+        Generar horarios
       </button>
       <div class="spinner-border text-primary d-none" id="spinner" role="status" aria-hidden="true"></div>
       <div class="text-warning-emphasis d-none" id="slowMsg">La generación está tardando más de lo esperado…</div>


### PR DESCRIPTION
## Summary
- Replace separate Excel and charts buttons on generator page with a single "Generar horarios" button
- Simplify frontend logic to handle one button and drop generate_charts flag
- Remove backend handling of generate_charts field while keeping result page exports

## Testing
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask'; ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689bc6507290832797ff4600d8d97947