### PR TITLE
Elimina parámetro generate_charts del generador

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -85,7 +85,7 @@ def generador():
 
         config = {}
         for key, value in request.form.items():
-            if key in {"csrf_token", "generate_charts"}:
+            if key == "csrf_token":
                 continue
             low = value.lower()
             if low in {"on", "true", "1"}:

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -3,13 +3,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const spinner = document.getElementById('spinner');
   const slowMsg = document.getElementById('slowMsg');
   const btnExcel = document.getElementById('btnExcel');
-  const btnCharts = document.getElementById('btnCharts');
-  let generateCharts = false;
 
-  if (!form || !spinner || !slowMsg || !btnExcel || !btnCharts) return;
+  if (!form || !spinner || !slowMsg || !btnExcel) return;
 
   form.addEventListener('submit', (e) => {
-    generateCharts = e.submitter === btnCharts;
     if (!form.checkValidity()) {
       e.preventDefault();
       e.stopPropagation();
@@ -17,12 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     btnExcel.disabled = true;
-    btnCharts.disabled = true;
     spinner.classList.remove('d-none');
     setTimeout(() => slowMsg.classList.remove('d-none'), 10000);
-  });
-
-  form.addEventListener('formdata', (e) => {
-    e.formData.append('generate_charts', generateCharts ? 'true' : 'false');
   });
 });

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -184,9 +184,6 @@
       <button type="submit" class="btn btn-primary px-4" id="btnExcel">
         Generar Excel
       </button>
-      <button type="submit" class="btn btn-secondary px-4" id="btnCharts">
-        Generar Gráficas
-      </button>
       <div class="spinner-border text-primary d-none" id="spinner" role="status" aria-hidden="true"></div>
       <div class="text-warning-emphasis d-none" id="slowMsg">La generación está tardando más de lo esperado…</div>
     </div>


### PR DESCRIPTION
## Summary
- Evita filtrar `generate_charts` en el backend del generador
- Simplifica `generador.js` al quitar el envío del parámetro
- Elimina el botón de gráficas del formulario

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689bc65175b08327baa4d019891c121d