### PR TITLE
Remove unused generate_charts field

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -85,7 +85,7 @@ def generador():
 
         config = {}
         for key, value in request.form.items():
-            if key == "csrf_token":
+            if key in {"csrf_token", "generate_charts"}:
                 continue
             low = value.lower()
             if low in {"on", "true", "1"}:


### PR DESCRIPTION
## Summary
- ignore deprecated `generate_charts` form field to avoid unused config entries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689bc57f38d483278b0781dda725a7b1