### PR TITLE
feat: add silent mode and debug control

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ This project creates optimized work schedules using Flask.
 
 3. Launch the Flask application:
    ```bash
-   flask --app website.app run
+   python run.py                     # production (no reloader)
+   FLASK_DEBUG=1 python run.py       # development with auto-reload
    ```
 
-   When prompted on /generador upload the demand Excel file.
+   `FLASK_DEBUG` enables the reloader and debugger when set to `1`. By default
+   the server runs silently without extra logging. Set `SCHEDULER_VERBOSE=1`
+   to display detailed progress from the optimizer.
 
    Para despliegues de producción utiliza Gunicorn y establece las opciones
    recomendadas mediante `GUNICORN_CMD_ARGS`:

--- a/run.py
+++ b/run.py
@@ -1,6 +1,14 @@
+import os
+
 from website import create_app
 
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(debug=True, host="127.0.0.1", port=5000)
+    debug = os.getenv("FLASK_DEBUG", "0") == "1"
+    app.run(
+        debug=debug,
+        use_reloader=debug,
+        host="127.0.0.1",
+        port=int(os.getenv("PORT", 5000)),
+    )

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -13,6 +13,7 @@ import csv
 from zipfile import ZipFile
 
 import numpy as np
+import builtins
 try:
     import matplotlib
     matplotlib.use("Agg")  # Use a non-GUI backend for server-side generation
@@ -26,6 +27,14 @@ try:
     import psutil
 except Exception:  # pragma: no cover - optional dependency
     psutil = None
+
+VERBOSE = os.getenv("SCHEDULER_VERBOSE", "0") == "1"
+
+def _print(*args, **kwargs):
+    if VERBOSE:
+        builtins.print(*args, **kwargs)
+
+print = _print
 
 # Lookup table for population count and global context
 POP = np.fromiter((bin(i).count("1") for i in range(256)), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- Add `SCHEDULER_VERBOSE` flag to silence scheduler output by default
- Allow toggling Flask debug mode via `FLASK_DEBUG` environment variable
- Document new runtime flags in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcb8b7cd88327a19a0151345ec4f1