### PR TITLE
Mejora estilo de tarjetas de KPIs en resultados

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -47,6 +47,24 @@ html,body {
 }
 
 /* =========================
+   KPI STAT CARDS
+   ========================= */
+.stat-card {
+  padding: 16px 20px;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100%;
+}
+
+.stat-card .small {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* =========================
    NAVBAR / OFFCANVAS
    ========================= */
 .navbar.bg-body-tertiary{

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -16,28 +16,28 @@
   <!-- KPIs -->
   {% if resultado and resultado.metrics %}
   <div class="row g-3 mb-4 text-center">
-    <div class="col-6 col-md-2">
-      <div class="card card-body">
+    <div class="col-6 col-md-4 col-lg-2">
+      <div class="card card-body h-100 stat-card">
         <div class="small text-muted">Total Agentes</div>
-        <div class="h3 mb-0">{{ resultado.metrics.total_agents or 0 }}</div>
+        <div class="h4 mb-0">{{ resultado.metrics.total_agents or 0 }}</div>
       </div>
     </div>
-    <div class="col-6 col-md-2">
-      <div class="card card-body">
+    <div class="col-6 col-md-4 col-lg-2">
+      <div class="card card-body h-100 stat-card">
         <div class="small text-muted">Full Time</div>
-        <div class="h3 mb-0">{{ resultado.metrics.ft_agents or 0 }}</div>
+        <div class="h4 mb-0">{{ resultado.metrics.ft_agents or 0 }}</div>
       </div>
     </div>
-    <div class="col-6 col-md-2">
-      <div class="card card-body">
+    <div class="col-6 col-md-4 col-lg-2">
+      <div class="card card-body h-100 stat-card">
         <div class="small text-muted">Part Time</div>
-        <div class="h3 mb-0">{{ resultado.metrics.pt_agents or 0 }}</div>
+        <div class="h4 mb-0">{{ resultado.metrics.pt_agents or 0 }}</div>
       </div>
     </div>
-    <div class="col-6 col-md-3">
-      <div class="card card-body">
+    <div class="col-6 col-md-4 col-lg-2">
+      <div class="card card-body h-100 stat-card">
         <div class="small text-muted">Cobertura Real</div>
-        <div class="h3 mb-0">
+        <div class="h4 mb-0">
           {% if resultado.metrics.coverage_percentage is not none %}
             {{ '%.1f'|format(resultado.metrics.coverage_percentage) }}%
           {% else %}
@@ -46,16 +46,16 @@
         </div>
       </div>
     </div>
-    <div class="col-6 col-md-1">
-      <div class="card card-body">
+    <div class="col-6 col-md-4 col-lg-2">
+      <div class="card card-body h-100 stat-card">
         <div class="small text-muted">Exceso</div>
-        <div class="h5 mb-0">{{ resultado.metrics.overstaffing or 0 }}</div>
+        <div class="h4 mb-0">{{ resultado.metrics.overstaffing or 0 }}</div>
       </div>
     </div>
-    <div class="col-6 col-md-2">
-      <div class="card card-body">
+    <div class="col-6 col-md-4 col-lg-2">
+      <div class="card card-body h-100 stat-card">
         <div class="small text-muted">Déficit</div>
-        <div class="h5 mb-0">{{ resultado.metrics.understaffing or 0 }}</div>
+        <div class="h4 mb-0">{{ resultado.metrics.understaffing or 0 }}</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Uniforma columnas y tipografía de KPIs en la página de resultados
- Añade clase `stat-card` con estilo flexible para las tarjetas

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_689e5b48c22483279dc6c0a159e87532