### PR TITLE
Add apps blueprint with index redirect

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 
 from .extensions import csrf, scheduler
 from .blueprints.core import bp as core_bp
+from .blueprints.apps import bp as apps_bp
 
 
 def create_app(config=None):
@@ -33,5 +34,6 @@ def create_app(config=None):
 
     # Blueprints
     app.register_blueprint(core_bp)
+    app.register_blueprint(apps_bp)
 
     return app

--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, redirect, url_for
+
+bp = Blueprint("apps", __name__, url_prefix="/apps")
+
+
+@bp.route("/")
+def index():
+    """Redirect to the default app or show a menu."""
+    return redirect(url_for("apps.erlang"))
+
+
+@bp.route("/erlang")
+def erlang():
+    """Placeholder for the Erlang app."""
+    return "Erlang app coming soon"


### PR DESCRIPTION
## Summary
- add `apps` blueprint with default index redirect to Erlang app
- register the new blueprint in the app factory

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689ea9e8132083278c2172d95394c26f