### PR TITLE
Add template layout and placeholders for analytics apps

### DIFF
--- a/website/templates/apps/_layout.html
+++ b/website/templates/apps/_layout.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="row">
+  <aside class="col-md-3 col-lg-2 mb-4">
+    <div class="list-group">
+      <a href="{{ url_for('core.generador') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.generador' else '' }}">Generador</a>
+      <a href="{{ url_for('core.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.erlang' else '' }}">Erlang</a>
+      <a href="{{ url_for('core.kpis') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.kpis' else '' }}">KPIs</a>
+      <a href="{{ url_for('core.timeseries') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.timeseries' else '' }}">Series</a>
+    </div>
+  </aside>
+  <div class="col">
+    {% block app_content %}{% endblock %}
+  </div>
+</div>
+{% endblock %}

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -1,0 +1,39 @@
+{% extends 'apps/_layout.html' %}
+
+{% block app_content %}
+<h2 class="fw-bold mb-4">Erlang</h2>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form id="erlang-form" class="needs-validation" novalidate>
+      <!-- Campos del formulario -->
+    </form>
+  </div>
+</div>
+
+<div class="row g-3 mb-4" id="erlang-metrics">
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">Metric A</div>
+  </div>
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">Metric B</div>
+  </div>
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">Metric C</div>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <div class="table-responsive">
+      <table id="erlang-table" class="table table-sm"></table>
+    </div>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <div id="erlang-chart"></div>
+  </div>
+</div>
+{% endblock %}

--- a/website/templates/apps/kpis.html
+++ b/website/templates/apps/kpis.html
@@ -1,0 +1,36 @@
+{% extends 'apps/_layout.html' %}
+
+{% block app_content %}
+<h2 class="fw-bold mb-4">KPIs</h2>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form id="kpis-form" class="row g-3">
+      <!-- Controles de formulario -->
+    </form>
+  </div>
+</div>
+
+<div class="row g-3 mb-4" id="kpis-metrics">
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">KPI 1</div>
+  </div>
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">KPI 2</div>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <div class="table-responsive">
+      <table id="kpis-table" class="table table-sm"></table>
+    </div>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <div id="kpis-chart"></div>
+  </div>
+</div>
+{% endblock %}

--- a/website/templates/apps/timeseries.html
+++ b/website/templates/apps/timeseries.html
@@ -1,0 +1,33 @@
+{% extends 'apps/_layout.html' %}
+
+{% block app_content %}
+<h2 class="fw-bold mb-4">Series</h2>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form id="timeseries-form" class="row g-3">
+      <!-- Elementos del formulario -->
+    </form>
+  </div>
+</div>
+
+<div class="row g-3 mb-4" id="timeseries-metrics">
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">Métrica 1</div>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <div class="table-responsive">
+      <table id="timeseries-table" class="table table-sm"></table>
+    </div>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <div id="timeseries-chart"></div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add shared layout with sidebar links to Generador, Erlang, KPIs and Series pages
- stub Erlang, KPIs and Series templates with form, metric, table and chart containers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ea9ea095083278a057bef9dd01ade