### PR TITLE
Add Erlang route for dynamic calculations

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 
 from .extensions import csrf, scheduler
 from .blueprints.core import bp as core_bp
+from .apps import bp as apps_bp
 
 
 def create_app(config=None):
@@ -33,5 +34,6 @@ def create_app(config=None):
 
     # Blueprints
     app.register_blueprint(core_bp)
+    app.register_blueprint(apps_bp)
 
     return app

--- a/website/apps.py
+++ b/website/apps.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, render_template, request
+import json
+import importlib
+
+bp = Blueprint("apps", __name__)
+
+
+@bp.route("/erlang", methods=["GET", "POST"])
+def erlang():
+    metrics = {}
+    figures = {}
+    messages = []
+
+    if request.method == "POST":
+        data = request.get_json(silent=True)
+        if not data:
+            data = request.form.to_dict()
+        submodule = data.pop("submodule", None)
+
+        # Convert parameter values using JSON if possible
+        params = {}
+        for k, v in data.items():
+            try:
+                params[k] = json.loads(v)
+            except Exception:
+                params[k] = v
+
+        try:
+            erlang_core = importlib.import_module("erlang_core")
+            func = getattr(erlang_core, submodule, None)
+            if callable(func):
+                result = func(**params)
+                figs = {}
+                if isinstance(result, tuple):
+                    metrics = result[0] if len(result) > 0 else {}
+                    figs = result[1] if len(result) > 1 else {}
+                elif isinstance(result, dict):
+                    metrics = result.get("metrics", {})
+                    figs = result.get("figures", {})
+                else:
+                    metrics = result
+                for name, fig in figs.items():
+                    try:
+                        figures[name] = fig.to_json()
+                    except Exception:
+                        pass
+            else:
+                messages.append("Submódulo inválido")
+        except Exception as exc:
+            messages.append(str(exc))
+
+    return render_template(
+        "erlang.html", metrics=metrics, figures=figures, messages=messages
+    )

--- a/website/templates/erlang.html
+++ b/website/templates/erlang.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Erlang</h2>
+
+{% if messages %}
+<div class="alert alert-warning">
+  <ul class="mb-0">
+  {% for msg in messages %}
+    <li>{{ msg }}</li>
+  {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+{% if metrics %}
+<h3>Métricas</h3>
+<ul>
+  {% for key, value in metrics.items() %}
+  <li><strong>{{ key }}:</strong> {{ value }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+{% if figures %}
+<h3>Gráficas</h3>
+{% for name, fig_json in figures.items() %}
+<pre id="fig-{{ name }}">{{ fig_json }}</pre>
+{% endfor %}
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- add blueprint route `/erlang` to execute erlang_core calculations and serialize figures
- register new apps blueprint and template for displaying metrics and graphs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eaa025b34832783de3fc55dfb4ccf