### PR TITLE
Add time series analysis route

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests==2.31.0
 python-dotenv==1.0.0
 Flask-WTF==1.2.2
 gunicorn==21.2.0
+plotly==5.24.1

--- a/tests/test_timeseries_route.py
+++ b/tests/test_timeseries_route.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+
+
+def _csrf_token(client, endpoint):
+    resp = client.get(endpoint)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    allowlist_module.add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_timeseries_get():
+    client = app.test_client()
+    login(client)
+    resp = client.get('/timeseries')
+    assert resp.status_code == 200
+    assert b'Series de Tiempo' in resp.data
+
+
+def test_timeseries_post():
+    client = app.test_client()
+    login(client)
+    token = _csrf_token(client, '/timeseries')
+    resp = client.post(
+        '/timeseries',
+        data={'method': 'rolling', 'window': '3', 'alpha': '0.5', 'csrf_token': token},
+    )
+    assert resp.status_code == 200
+    assert b'tsChart' in resp.data
+

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -34,6 +34,7 @@
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item"><a href="{{ url_for('core.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generador' else '' }}">Generador</a></li>
             <li class="nav-item"><a href="{{ url_for('core.resultados') }}" class="nav-link {{ 'active' if request.endpoint=='resultados' else '' }}">Resultados</a></li>
+            <li class="nav-item"><a href="{{ url_for('core.timeseries') }}" class="nav-link {{ 'active' if request.endpoint=='timeseries' else '' }}">Timeseries</a></li>
             <li class="nav-item"><a href="{{ url_for('core.configuracion') }}" class="nav-link {{ 'active' if request.endpoint=='configuracion' else '' }}">Configuración</a></li>
           </ul>
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">

--- a/website/templates/timeseries.html
+++ b/website/templates/timeseries.html
@@ -1,0 +1,46 @@
+{% extends 'base.html' %}
+{% block content %}
+
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <h2 class="mb-0 fw-bold">Series de Tiempo</h2>
+  <span class="text-muted small">Demo de suavizado y pronóstico</span>
+ </div>
+
+<form method="post" class="mb-4">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label for="method" class="form-label">Método</label>
+      <select id="method" name="method" class="form-select">
+        <option value="rolling">Media móvil</option>
+        <option value="exp">Suavizado exponencial</option>
+      </select>
+    </div>
+    <div class="col-md-4">
+      <label for="window" class="form-label">Ventana</label>
+      <input type="number" id="window" name="window" min="1" value="5" class="form-control">
+    </div>
+    <div class="col-md-4">
+      <label for="alpha" class="form-label">Parámetro</label>
+      <input type="number" step="0.1" id="alpha" name="alpha" value="0.3" class="form-control">
+    </div>
+  </div>
+  <div class="mt-3">
+    <button type="submit" class="btn btn-primary">Procesar</button>
+  </div>
+</form>
+
+{% if fig_json %}
+  <div id="tsChart" style="height:400px"></div>
+  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+  <script>
+    const fig = {{ fig_json|safe }};
+    Plotly.react('tsChart', fig.data, fig.layout);
+  </script>
+  {% if metrics %}
+    <pre class="mt-3">{{ metrics|tojson(indent=2) }}</pre>
+  {% endif %}
+{% endif %}
+
+{% endblock %}
+

--- a/website/utils/__init__.py
+++ b/website/utils/__init__.py
@@ -1,0 +1,11 @@
+"""Utility helpers exposed at package level."""
+
+from .allowlist import add_to_allowlist, verify_user  # noqa: F401
+from .timeseries import timeseries_core, TimeSeriesResult  # noqa: F401
+
+__all__ = [
+    "add_to_allowlist",
+    "verify_user",
+    "timeseries_core",
+    "TimeSeriesResult",
+]

--- a/website/utils/timeseries.py
+++ b/website/utils/timeseries.py
@@ -1,0 +1,98 @@
+"""Utility functions for simple time series smoothing and forecasting.
+
+This module exposes a :func:`timeseries_core` helper used by the web
+application to generate a smoothed series and a naive forecast.  The function
+returns a Plotly ``Figure`` alongside some basic metrics which are displayed in
+the UI.
+
+The implementation intentionally keeps the logic lightweight – it does not aim
+to be a full fledged forecasting library but rather a demonstrative example
+that produces deterministic results for testing purposes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from math import sin
+import plotly.graph_objects as go
+
+
+@dataclass
+class TimeSeriesResult:
+    """Container for the objects returned by :func:`timeseries_core`."""
+
+    figure: go.Figure
+    metrics: Dict[str, float]
+
+
+def timeseries_core(
+    method: str = "rolling",
+    window: int = 5,
+    params: Dict[str, float] | None = None,
+) -> TimeSeriesResult:
+    """Generate a simple smoothed time series and naive forecast.
+
+    Parameters
+    ----------
+    method:
+        Smoothing method. Supported values are ``"rolling"`` for a moving
+        average and ``"exp"`` for exponential smoothing.
+    window:
+        Size of the window used for smoothing and forecasting.
+    params:
+        Optional dictionary with extra parameters.  ``alpha`` is recognised when
+        ``method`` is ``"exp"``.
+
+    Returns
+    -------
+    TimeSeriesResult
+        A container with the generated Plotly figure and a dictionary of
+        metrics.
+    """
+
+    if params is None:
+        params = {}
+
+    # Deterministic toy data: a noisy upward trend.
+    rng = list(range(30))
+    series = [i / 30 + 0.1 * sin(i / 2) for i in rng]
+
+    # Smoothing
+    if method == "exp":
+        alpha = float(params.get("alpha", 0.3))
+        smooth: List[float] = []
+        for x in series:
+            if not smooth:
+                smooth.append(x)
+            else:
+                smooth.append(alpha * x + (1 - alpha) * smooth[-1])
+    else:
+        smooth = []
+        for i in range(len(series)):
+            start = max(0, i + 1 - window)
+            segment = series[start : i + 1]
+            smooth.append(sum(segment) / len(segment))
+
+    # Naive forecast: extend last smoothed value ``window`` steps ahead.
+    forecast_index = list(range(len(series), len(series) + window))
+    forecast = [smooth[-1]] * window
+
+    # Build Plotly figure.
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=rng, y=series, name="original"))
+    fig.add_trace(go.Scatter(x=rng, y=smooth, name="smooth"))
+    fig.add_trace(go.Scatter(x=forecast_index, y=forecast, name="forecast"))
+
+    metrics = {
+        "original_mean": sum(series) / len(series),
+        "smooth_mean": sum(smooth) / len(smooth),
+        "forecast_last": forecast[-1],
+    }
+
+    return TimeSeriesResult(fig, metrics)
+
+
+__all__ = ["timeseries_core", "TimeSeriesResult"]
+


### PR DESCRIPTION
## Summary
- incorporate interactive timeseries demo with smoothing and forecast
- expose lightweight timeseries_core utility and template rendered via Plotly
- add coverage and navigation entry for new timeseries feature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eaa052ab48327b39fea9ed2113897