### PR TITLE
Add shared app layout resources

### DIFF
--- a/website/static/css/apps.css
+++ b/website/static/css/apps.css
@@ -1,0 +1,13 @@
+/* Layout for app metric cards */
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.metric-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}

--- a/website/static/js/apps_common.js
+++ b/website/static/js/apps_common.js
@@ -1,0 +1,10 @@
+/**
+ * Utilities to mount Plotly figures.
+ * Usage: mountPlot('chartId', figureJson)
+ */
+window.mountPlot = function (containerId, figure) {
+  if (!window.Plotly) return;
+  const el = document.getElementById(containerId);
+  if (!el || !figure) return;
+  Plotly.react(el, figure.data, figure.layout || {}, {responsive: true});
+};

--- a/website/templates/_layout.html
+++ b/website/templates/_layout.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="es" data-bs-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title or 'Horarios' }}</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/apps.css') }}">
+</head>
+<body>
+    {% set is_public = request.endpoint in ['core.landing','core.index','core.checkout','core.subscribe'] %}
+  {% set is_auth   = session.get('user') %}
+  {% from 'macros.html' import user_dropdown %}
+
+  <header>
+    <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom sticky-top">
+      <div class="container-xxl">
+        {# BRAND — puntito verde + texto #}
+        <a class="navbar-brand d-flex align-items-center" href="/">
+          <span class="brand-dot me-2" aria-hidden="true"></span>
+          <span class="fs-5 fw-semibold">Schedules</span>
+        </a>
+
+        {% if not is_public and is_auth %}
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMain" aria-controls="navMain" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navMain">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a href="{{ url_for('core.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generador' else '' }}">Generador</a></li>
+            <li class="nav-item"><a href="{{ url_for('core.resultados') }}" class="nav-link {{ 'active' if request.endpoint=='resultados' else '' }}">Resultados</a></li>
+            <li class="nav-item"><a href="{{ url_for('core.configuracion') }}" class="nav-link {{ 'active' if request.endpoint=='configuracion' else '' }}">Configuración</a></li>
+          </ul>
+          <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
+            <i class="bi bi-moon" aria-hidden="true"></i>
+          </button>
+          {{ user_dropdown(is_auth) }}
+        </div>
+        {% else %}
+        <div class="d-flex ms-auto align-items-center">
+          <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
+            <i class="bi bi-moon" aria-hidden="true"></i>
+          </button>
+          {{ user_dropdown(is_auth) }}
+        </div>
+        {% endif %}
+      </div>
+    </nav>
+  </header>
+
+  <main class="container-xxl py-4">
+    {% block content %}{% endblock %}
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+  <script src="{{ url_for('static', filename='js/apps_common.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `apps.css` grid and flex helpers for uniform metric cards
- Provide `apps_common.js` utility using `Plotly.react` to mount figures
- Include new CSS and JS assets from `_layout.html`

## Testing
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689eaa0625e88327931c6966dfc60028