### PR TITLE
Add tests for app routes with CSRF verification

### DIFF
--- a/tests/test_apps_erlang.py
+++ b/tests/test_apps_erlang.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _get_html_and_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    m = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return html, m.group(1) if m else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    _, token = _get_html_and_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_apps_erlang_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/erlang')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_apps_erlang_page_contains_csrf_and_heading():
+    client = app.test_client()
+    login(client)
+    html, token = _get_html_and_token(client, '/apps/erlang')
+    assert token
+    assert 'Erlang App' in html

--- a/tests/test_apps_kpis.py
+++ b/tests/test_apps_kpis.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _get_html_and_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    m = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return html, m.group(1) if m else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    _, token = _get_html_and_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_apps_kpis_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/kpis')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_apps_kpis_page_contains_csrf_and_heading():
+    client = app.test_client()
+    login(client)
+    html, token = _get_html_and_token(client, '/apps/kpis')
+    assert token
+    assert 'KPIs App' in html

--- a/tests/test_apps_timeseries.py
+++ b/tests/test_apps_timeseries.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _get_html_and_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    m = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return html, m.group(1) if m else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    _, token = _get_html_and_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_apps_timeseries_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/timeseries')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_apps_timeseries_page_contains_csrf_and_heading():
+    client = app.test_client()
+    login(client)
+    html, token = _get_html_and_token(client, '/apps/timeseries')
+    assert token
+    assert 'Timeseries App' in html

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -253,6 +253,21 @@ def configuracion():
     return render_template("configuracion.html")
 
 
+@bp.route("/apps/erlang", methods=["GET", "POST"])
+@login_required
+def apps_erlang():
+    return render_template("apps/erlang.html")
+
+@bp.route("/apps/kpis", methods=["GET", "POST"])
+@login_required
+def apps_kpis():
+    return render_template("apps/kpis.html")
+
+@bp.route("/apps/timeseries", methods=["GET", "POST"])
+@login_required
+def apps_timeseries():
+    return render_template("apps/timeseries.html")
+
 @bp.route("/contacto")
 def contacto():
     return render_template("contacto.html")

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Erlang App</h1>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <input type="text" name="value">
+</form>
+{% endblock %}

--- a/website/templates/apps/kpis.html
+++ b/website/templates/apps/kpis.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>KPIs App</h1>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+</form>
+{% endblock %}

--- a/website/templates/apps/timeseries.html
+++ b/website/templates/apps/timeseries.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Timeseries App</h1>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add Erlang, KPIs, and Timeseries app pages with CSRF-protected forms
- Test each app route for login requirement, CSRF token presence, and key content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eaa08e390832798d25a90742e21d6