### PR TITLE
feat: add data science dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ python-dotenv==1.0.0
 Flask-WTF==1.2.2
 gunicorn==21.2.0
 plotly==5.18.0
+scipy==1.11.4
+statsmodels==0.14.1
+scikit-learn==1.3.2


### PR DESCRIPTION
## Summary
- add scipy, statsmodels, and scikit-learn to requirements
- keep existing dependency pins intact

## Testing
- `pip install scipy==1.11.4 statsmodels==0.14.1 scikit-learn==1.3.2`
- `pip install flask==2.3.3`
- `pip install python-dotenv==1.0.0`
- `pip install Flask-WTF==1.2.2`
- `pip install openpyxl==3.1.2`
- `pip install plotly==5.18.0`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb533db8c8327a7967e2a1b2544fa