### PR TITLE
Add placeholder tests for apps routes

### DIFF
--- a/tests/test_apps_erlang.py
+++ b/tests/test_apps_erlang.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.utils.kpis_core', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_erlang_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/erlang')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_erlang_authenticated_get():
+    client = app.test_client()
+    login(client)
+    response = client.get('/apps/erlang')
+    assert response.status_code == 200
+    assert b'erlang-form' in response.data or b'Erlang app coming soon' in response.data
+
+
+@pytest.mark.xfail(reason="POST handler not yet implemented")
+def test_erlang_post_placeholder():
+    client = app.test_client()
+    login(client)
+    token = _csrf_token(client, '/apps/erlang')
+    response = client.post(
+        '/apps/erlang',
+        data={'sample': 'data', 'csrf_token': token},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'coming soon' in response.data

--- a/tests/test_apps_kpis.py
+++ b/tests/test_apps_kpis.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.utils.kpis_core', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_kpis_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/kpis')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_kpis_authenticated_get():
+    client = app.test_client()
+    login(client)
+    response = client.get('/apps/kpis')
+    assert response.status_code == 200
+    assert b'kpis-form' in response.data or b'coming soon' in response.data
+
+
+@pytest.mark.xfail(reason="POST handler not yet implemented")
+def test_kpis_post_placeholder():
+    client = app.test_client()
+    login(client)
+    token = _csrf_token(client, '/apps/kpis')
+    response = client.post(
+        '/apps/kpis',
+        data={'sample': 'data', 'csrf_token': token},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'placeholder' in response.data or b'coming soon' in response.data

--- a/tests/test_apps_timeseries.py
+++ b/tests/test_apps_timeseries.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.utils.kpis_core', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_timeseries_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/timeseries')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_timeseries_authenticated_get():
+    client = app.test_client()
+    login(client)
+    response = client.get('/apps/timeseries')
+    assert response.status_code == 200
+    assert b'timeseries-form' in response.data or b'coming soon' in response.data
+
+
+@pytest.mark.xfail(reason="POST handler not yet implemented")
+def test_timeseries_post_placeholder():
+    client = app.test_client()
+    login(client)
+    token = _csrf_token(client, '/apps/timeseries')
+    response = client.post(
+        '/apps/timeseries',
+        data={'sample': 'data', 'csrf_token': token},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'placeholder' in response.data or b'coming soon' in response.data


### PR DESCRIPTION
## Summary
- add tests for `/apps/erlang`, `/apps/kpis`, and `/apps/timeseries`
- verify redirects to login and placeholder content when authenticated

## Testing
- `pytest tests/test_apps_erlang.py tests/test_apps_kpis.py tests/test_apps_timeseries.py -q` (fails: assert status codes)


------
https://chatgpt.com/codex/tasks/task_e_689eb534b6cc832786c99266a4495723