### PR TITLE
Add time series demo with navigation link and tests

### DIFF
--- a/tests/test_apps_timeseries.py
+++ b/tests/test_apps_timeseries.py
@@ -54,15 +54,16 @@ def test_timeseries_authenticated_get():
     assert b'timeseries-form' in response.data or b'coming soon' in response.data
 
 
-@pytest.mark.xfail(reason="POST handler not yet implemented")
-def test_timeseries_post_placeholder():
+def test_timeseries_post_returns_results():
     client = app.test_client()
     login(client)
     token = _csrf_token(client, '/apps/timeseries')
     response = client.post(
         '/apps/timeseries',
-        data={'sample': 'data', 'csrf_token': token},
+        data={'values': '1,2,3,4', 'csrf_token': token},
         follow_redirects=True,
     )
     assert response.status_code == 200
-    assert b'placeholder' in response.data or b'coming soon' in response.data
+    html = response.get_data(as_text=True)
+    assert 'timeseries-table' in html
+    assert 'data-figure' in html

--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -5,13 +5,20 @@ interactive utilities.  Each view delegates heavy computations to functions in
 ``website.other`` so that the routes themselves remain thin controllers.
 """
 
-from flask import Blueprint, redirect, render_template, request, url_for
+from flask import Blueprint, redirect, render_template, request, url_for, session
 import json
 import plotly.graph_objects as go
 
 from ..other import timeseries_core
 
 bp = Blueprint("apps", __name__, url_prefix="/apps")
+
+
+@bp.before_request
+def require_login():  # pragma: no cover - simple auth gate
+    """Redirect users to the login page when not authenticated."""
+    if "user" not in session:
+        return redirect(url_for("core.login"))
 
 
 @bp.route("/")

--- a/website/other/timeseries_core.py
+++ b/website/other/timeseries_core.py
@@ -93,3 +93,54 @@ def plot_learning_history(history: Dict[str, Any], demand_signature: str) -> Dic
         fig = go.Figure(data=[go.Scatter(x=timestamps, y=scores, mode="lines+markers")])
     fig.update_layout(title="Evolución del Score", xaxis_title="Timestamp", yaxis_title="Score")
     return fig.to_dict()
+
+
+def run(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Basic processing pipeline for the demo time series app.
+
+    The function expects a key ``values`` containing either an iterable of
+    numbers or a comma separated string. It returns summary metrics, a table of
+    the points and a Plotly figure representing the series.
+
+    Parameters
+    ----------
+    params:
+        Dictionary of input parameters from the form.
+
+    Returns
+    -------
+    dict
+        ``metrics``: basic statistics of the series
+        ``table``: list of dicts with ``index`` and ``value``
+        ``figure``: Plotly Figure object with a line chart
+    """
+
+    values = params.get("values", [])
+    if isinstance(values, str):
+        try:
+            values = [float(v) for v in values.split(",") if v.strip()]
+        except Exception:
+            values = []
+    else:
+        try:
+            values = [float(v) for v in values]
+        except Exception:
+            values = []
+
+    arr = np.array(values, dtype=float)
+
+    metrics: Dict[str, Any] = {}
+    if arr.size:
+        metrics = {
+            "count": int(arr.size),
+            "mean": float(arr.mean()),
+            "min": float(arr.min()),
+            "max": float(arr.max()),
+        }
+
+    table = [{"index": int(i), "value": float(v)} for i, v in enumerate(arr.tolist())]
+
+    fig = go.Figure(data=[go.Scatter(y=arr.tolist(), mode="lines+markers")])
+    fig.update_layout(title="Serie de tiempo", xaxis_title="Índice", yaxis_title="Valor")
+
+    return {"metrics": metrics, "table": table, "figure": fig}

--- a/website/templates/apps/_layout.html
+++ b/website/templates/apps/_layout.html
@@ -5,9 +5,9 @@
   <aside class="col-md-3 col-lg-2 mb-4">
     <div class="list-group">
       <a href="{{ url_for('core.generador') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.generador' else '' }}">Generador</a>
-      <a href="{{ url_for('core.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.erlang' else '' }}">Erlang</a>
+      <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.erlang' else '' }}">Erlang</a>
       <a href="{{ url_for('core.kpis') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.kpis' else '' }}">KPIs</a>
-      <a href="{{ url_for('core.timeseries') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.timeseries' else '' }}">Series</a>
+      <a href="{{ url_for('apps.timeseries') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.timeseries' else '' }}">Series</a>
     </div>
   </aside>
   <div class="col">

--- a/website/templates/apps/timeseries.html
+++ b/website/templates/apps/timeseries.html
@@ -5,29 +5,59 @@
 
 <div class="card mb-4">
   <div class="card-body">
-    <form id="timeseries-form" class="row g-3">
-      <!-- Elementos del formulario -->
+    <form id="timeseries-form" class="row g-3" method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-8">
+        <label for="values" class="form-label">Valores (separados por coma)</label>
+        <input type="text" class="form-control" id="values" name="values" placeholder="1,2,3,4" required>
+      </div>
+      <div class="col-md-4 align-self-end">
+        <button class="btn btn-primary" type="submit">Procesar</button>
+      </div>
     </form>
   </div>
 </div>
 
+{% if metrics %}
 <div class="row g-3 mb-4" id="timeseries-metrics">
+  {% for key, value in metrics.items() %}
   <div class="col-md-3">
-    <div class="p-3 border rounded text-center">Métrica 1</div>
+    <div class="p-3 border rounded text-center">{{ key }}: {{ value }}</div>
   </div>
+  {% endfor %}
 </div>
+{% endif %}
 
+{% if table %}
 <div class="card mb-4">
   <div class="card-body">
     <div class="table-responsive">
-      <table id="timeseries-table" class="table table-sm"></table>
+      <table id="timeseries-table" class="table table-sm">
+        <thead>
+          <tr><th>Índice</th><th>Valor</th></tr>
+        </thead>
+        <tbody>
+          {% for row in table %}
+          <tr><td>{{ row.index }}</td><td>{{ row.value }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
   </div>
 </div>
+{% endif %}
 
+{% if figure_json %}
 <div class="card mb-4">
   <div class="card-body">
-    <div id="timeseries-chart"></div>
+    <div id="timeseries-chart" data-figure='{{ figure_json | tojson | safe }}'></div>
   </div>
 </div>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script>
+  const chartEl = document.getElementById('timeseries-chart');
+  const fig = JSON.parse(chartEl.dataset.figure);
+  Plotly.react(chartEl, fig.data, fig.layout);
+</script>
+{% endif %}
 {% endblock %}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -35,6 +35,7 @@
             <li class="nav-item"><a href="{{ url_for('core.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generador' else '' }}">Generador</a></li>
             <li class="nav-item"><a href="{{ url_for('core.resultados') }}" class="nav-link {{ 'active' if request.endpoint=='resultados' else '' }}">Resultados</a></li>
             <li class="nav-item"><a href="{{ url_for('core.configuracion') }}" class="nav-link {{ 'active' if request.endpoint=='configuracion' else '' }}">Configuración</a></li>
+            <li class="nav-item"><a href="{{ url_for('apps.timeseries') }}" class="nav-link {{ 'active' if request.endpoint=='apps.timeseries' else '' }}">Series</a></li>
           </ul>
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
             <i class="bi bi-moon" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- add navigation link to the time series demo
- implement `timeseries_core.run` returning metrics, table and plotly figure
- build interactive template for entering values and showing results
- cover the time series POST flow with unit tests

## Testing
- `pytest tests/test_apps_timeseries.py -q`
- `pytest tests/test_navigation_dropdown.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ebb6155508327bde589ef02be1d88