### PR TITLE
Add navigation links for demo apps

### DIFF
--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client):
+    resp = client.get('/login')
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client)
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_nav_links_authenticated():
+    client = app.test_client()
+    login(client)
+    response = client.get('/generador')
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert '/apps/erlang' in html
+    assert '/apps/timeseries' in html
+    assert '/apps/predictivo' in html

--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -33,6 +33,12 @@ def erlang():
     return "Erlang app coming soon"
 
 
+@bp.route("/predictivo")
+def predictivo():
+    """Placeholder for the Predictive app."""
+    return "Predictive app coming soon"
+
+
 @bp.route("/timeseries", methods=["GET", "POST"])
 def timeseries():
     """Render the time series exploration interface.

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -35,7 +35,9 @@
             <li class="nav-item"><a href="{{ url_for('core.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generador' else '' }}">Generador</a></li>
             <li class="nav-item"><a href="{{ url_for('core.resultados') }}" class="nav-link {{ 'active' if request.endpoint=='resultados' else '' }}">Resultados</a></li>
             <li class="nav-item"><a href="{{ url_for('core.configuracion') }}" class="nav-link {{ 'active' if request.endpoint=='configuracion' else '' }}">Configuración</a></li>
+            <li class="nav-item"><a href="{{ url_for('apps.erlang') }}" class="nav-link {{ 'active' if request.endpoint=='apps.erlang' else '' }}">Erlang</a></li>
             <li class="nav-item"><a href="{{ url_for('apps.timeseries') }}" class="nav-link {{ 'active' if request.endpoint=='apps.timeseries' else '' }}">Series</a></li>
+            <li class="nav-item"><a href="{{ url_for('apps.predictivo') }}" class="nav-link {{ 'active' if request.endpoint=='apps.predictivo' else '' }}">Predictivo</a></li>
           </ul>
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
             <i class="bi bi-moon" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- extend main navigation with links to Erlang, Series, and Predictive demo apps
- add placeholder route for `/apps/predictivo`
- test that authenticated users see app links in navigation bar

## Testing
- `pytest tests/test_navigation_dropdown.py tests/test_apps_erlang.py tests/test_apps_timeseries.py tests/test_navigation_links.py -q`
- `pytest -q` *(fails: kpis routes missing; AttributeError in kpis_core)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe8e1c3483279371d6b6ecd3c3c4