### PR TITLE
Add predictive forecasting app

### DIFF
--- a/tests/test_apps_predictivo.py
+++ b/tests/test_apps_predictivo.py
@@ -1,0 +1,82 @@
+import io
+import os
+import sys
+import types
+
+import io
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.utils.kpis_core', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_predictivo_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/predictivo')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_predictivo_authenticated_get():
+    client = app.test_client()
+    login(client)
+    response = client.get('/apps/predictivo')
+    assert response.status_code == 200
+    assert b'predictivo-form' in response.data
+
+
+def test_predictivo_post_returns_results():
+    client = app.test_client()
+    login(client)
+    token = _csrf_token(client, '/apps/predictivo')
+    csv_content = 'date,value\n2023-01-01,1\n2023-02-01,2\n2023-03-01,3\n'
+    data = {
+        'steps_horizon': '2',
+        'csrf_token': token,
+        'file': (io.BytesIO(csv_content.encode('utf-8')), 'data.csv'),
+    }
+    response = client.post(
+        '/apps/predictivo',
+        data=data,
+        content_type='multipart/form-data',
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'predictivo-table' in html
+    assert 'predictivo-download' in html

--- a/website/other/modelo_predictivo_core.py
+++ b/website/other/modelo_predictivo_core.py
@@ -1,0 +1,105 @@
+"""Simplified predictive model core module.
+
+This module exposes a :func:`run` function used by the Flask blueprint to
+produce a basic forecast from an uploaded CSV/Excel file.  The implementation
+is intentionally lightweight compared to the original Streamlit prototype but
+keeps a similar interface: it returns a dictionary with ``metrics``,
+``table`` and a binary ``file_bytes`` for download.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any, Dict
+
+import pandas as pd
+from statsmodels.tsa.holtwinters import ExponentialSmoothing
+
+
+def detectar_frecuencia(series: pd.Series) -> str:
+    """Infer the frequency of a time indexed series.
+
+    Falls back to simple heuristics when ``pd.infer_freq`` fails.
+    """
+
+    freq = pd.infer_freq(series.index)
+    if freq:
+        return freq
+    dias = series.index.to_series().diff().dt.days.mean()
+    if dias <= 1.5:
+        return "D"
+    if dias <= 8:
+        return "W"
+    return "MS"
+
+
+def calcular_estacionalidad(series: pd.Series) -> int:
+    """Return a seasonal period length based on available observations."""
+
+    n = len(series)
+    if n >= 24:
+        return 12
+    if n >= 18:
+        return 6
+    if n >= 12:
+        return 4
+    if n >= 8:
+        return 2
+    return 1
+
+
+def run(file_obj, steps_horizon: int = 6) -> Dict[str, Any]:
+    """Execute a forecast from an uploaded file.
+
+    Parameters
+    ----------
+    file_obj:
+        File-like object containing two columns: date and value.
+    steps_horizon:
+        Number of future periods to forecast.
+
+    Returns
+    -------
+    dict
+        ``{"metrics": ..., "table": ..., "file_bytes": ...}``
+    """
+
+    # Load the dataset
+    name = getattr(file_obj, "filename", "")
+    if name.endswith(("xlsx", "xls")):
+        raw = pd.read_excel(file_obj)
+    else:
+        raw = pd.read_csv(file_obj)
+
+    raw.iloc[:, 0] = pd.to_datetime(raw.iloc[:, 0], errors="coerce")
+    raw.set_index(raw.columns[0], inplace=True)
+    series = raw.iloc[:, 0].ffill()
+
+    # Basic analysis
+    freq = detectar_frecuencia(series)
+    m = calcular_estacionalidad(series)
+
+    seasonal = "add" if m > 1 else None
+    model = ExponentialSmoothing(
+        series, trend="add", seasonal=seasonal, seasonal_periods=m if m > 1 else None
+    ).fit()
+    fc = model.forecast(steps_horizon)
+    offset = pd.tseries.frequencies.to_offset(freq)
+    dates = pd.date_range(series.index[-1] + offset, periods=steps_horizon, freq=freq)
+    fc_df = pd.DataFrame({"Pronóstico": fc}, index=dates)
+
+    # Prepare data for the template and download link
+    table = [
+        {"Fecha": idx.strftime("%Y-%m-%d"), "Pronóstico": float(val)}
+        for idx, val in fc_df["Pronóstico"].items()
+    ]
+
+    buf = BytesIO()
+    fc_df.to_csv(buf)
+    file_bytes = buf.getvalue()
+
+    return {
+        "metrics": {"frecuencia": freq, "estacionalidad": m},
+        "table": table,
+        "file_bytes": file_bytes,
+    }

--- a/website/templates/apps/predictivo.html
+++ b/website/templates/apps/predictivo.html
@@ -1,0 +1,65 @@
+{% extends 'apps/_layout.html' %}
+
+{% block app_content %}
+<h2 class="fw-bold mb-4">Modelo Predictivo</h2>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form id="predictivo-form" class="row g-3" method="post" enctype="multipart/form-data">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-6">
+        <label for="file" class="form-label">Archivo de datos</label>
+        <input type="file" class="form-control" id="file" name="file" required>
+      </div>
+      <div class="col-md-4">
+        <label for="steps_horizon" class="form-label">Pasos futuros</label>
+        <input type="number" class="form-control" id="steps_horizon" name="steps_horizon" value="6" min="1" max="200" required>
+      </div>
+      <div class="col-md-2 align-self-end">
+        <button class="btn btn-primary w-100" type="submit">Ejecutar Pronóstico</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% if metrics %}
+<div class="row g-3 mb-4" id="predictivo-metrics">
+  {% for key, value in metrics.items() %}
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">{{ key }}: {{ value }}</div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if table %}
+<div class="card mb-4">
+  <div class="card-body">
+    <div class="table-responsive">
+      <table id="predictivo-table" class="table table-sm">
+        <thead>
+          <tr>
+            {% for col in table[0].keys() %}
+            <th>{{ col }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in table %}
+          <tr>
+            {% for value in row.values() %}
+            <td>{{ value }}</td>
+            {% endfor %}
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% if download %}
+    <a id="predictivo-download" class="btn btn-secondary mt-3" href="data:application/octet-stream;base64,{{ download }}" download="resultados.csv">Descargar Resultados</a>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- add predictive forecasting route and template with file upload and horizon selection
- implement lightweight forecasting core using Holt-Winters
- cover predictive workflow with tests

## Testing
- `pytest tests/test_apps_predictivo.py tests/test_apps_timeseries.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f6ab5bcd08327881fd0e6b6c8b609