### PR TITLE
feat: expand erlang calculator

### DIFF
--- a/tests/test_apps_erlang.py
+++ b/tests/test_apps_erlang.py
@@ -57,20 +57,40 @@ def test_erlang_authenticated_get():
 def test_erlang_post_calculates(monkeypatch):
     from website.other import erlang_core
 
-    def fake_analyze(matrix):
-        return {"required_agents": 7.5}
+    def fake_calc(**kwargs):
+        return {
+            "service_level": 0.8,
+            "asa": 20,
+            "occupancy": 0.5,
+            "required_agents": 5,
+        }
 
-    monkeypatch.setattr(erlang_core, "analyze_demand_matrix", fake_analyze)
+    monkeypatch.setattr(erlang_core, "calculate_erlang_metrics", fake_calc)
 
     client = app.test_client()
     login(client)
     token = _csrf_token(client, '/apps/erlang')
     response = client.post(
         '/apps/erlang',
-        data={'calls': '10', 'agents': '2', 'csrf_token': token},
+        data={
+            'calls': '100',
+            'aht': '30',
+            'sl': '80',
+            'awl': '20',
+            'agents': '10',
+            'max_agents': '15',
+            'calc_type': 'service',
+            'csrf_token': token,
+        },
         follow_redirects=True,
     )
     assert response.status_code == 200
     html = response.get_data(as_text=True)
-    assert 'required_agents' in html
-    assert '7.5' in html
+    assert 'SL:' in html
+    assert 'ASA:' in html
+    assert 'Ocupación:' in html
+    assert 'Requeridos:' in html
+    assert '0.8' in html
+    assert '20' in html
+    assert '0.5' in html
+    assert '5' in html

--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -34,16 +34,25 @@ def erlang():
     metrics = {}
 
     if request.method == "POST":
-        calls = request.form.get("calls", type=float, default=0) or 0
-        agents = request.form.get("agents", type=float, default=0) or 0
+        calls = request.form.get("calls", type=float, default=0) or 0.0
+        aht = request.form.get("aht", type=float, default=0) or 0.0
+        sl = request.form.get("sl", type=float, default=0) or 0.0
+        awl = request.form.get("awl", type=float, default=0) or 0.0
+        agents = request.form.get("agents", type=int, default=0) or 0
+        max_agents = request.form.get("max_agents", type=int, default=agents) or agents
+        calc_type = request.form.get("calc_type", default="service")
 
-        # Create a simple demand matrix placing the calls in the first slot.
-        demand = [[calls] + [0.0] * 23] + [[0.0] * 24 for _ in range(6)]
+        sl_target = sl / 100 if sl > 1 else sl
 
-        result = erlang_core.analyze_demand_matrix(demand)
-        if isinstance(result, dict):
-            metrics = result
-            metrics["agents"] = agents
+        metrics = erlang_core.calculate_erlang_metrics(
+            calls=calls,
+            aht=aht,
+            sl_target=sl_target,
+            awt=awl,
+            agents=agents,
+            max_agents=max_agents,
+            calc_type=calc_type,
+        )
 
     return render_template("apps/erlang.html", metrics=metrics)
 

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -7,13 +7,36 @@
   <div class="card-body">
     <form id="erlang-form" class="row g-3" method="post">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="col-md-6">
+      <div class="col-md-4">
         <label for="calls" class="form-label">Llamadas</label>
         <input type="number" class="form-control" id="calls" name="calls" required>
       </div>
-      <div class="col-md-6">
+      <div class="col-md-4">
+        <label for="aht" class="form-label">AHT (seg)</label>
+        <input type="number" class="form-control" id="aht" name="aht" required>
+      </div>
+      <div class="col-md-4">
         <label for="agents" class="form-label">Agentes</label>
         <input type="number" class="form-control" id="agents" name="agents" required>
+      </div>
+      <div class="col-md-4">
+        <label for="sl" class="form-label">SL objetivo (%)</label>
+        <input type="number" class="form-control" id="sl" name="sl" required>
+      </div>
+      <div class="col-md-4">
+        <label for="awl" class="form-label">AWL (seg)</label>
+        <input type="number" class="form-control" id="awl" name="awl" required>
+      </div>
+      <div class="col-md-4">
+        <label for="max_agents" class="form-label">Agentes máximos</label>
+        <input type="number" class="form-control" id="max_agents" name="max_agents" required>
+      </div>
+      <div class="col-md-4">
+        <label for="calc_type" class="form-label">Tipo de cálculo</label>
+        <select class="form-select" id="calc_type" name="calc_type">
+          <option value="service">Métricas</option>
+          <option value="required">Agentes requeridos</option>
+        </select>
       </div>
       <div class="col-12">
         <button class="btn btn-primary" type="submit">Calcular</button>
@@ -24,11 +47,18 @@
 
 {% if metrics %}
 <div class="row g-3 mb-4" id="erlang-metrics">
-  {% for key, value in metrics.items() %}
   <div class="col-md-3">
-    <div class="p-3 border rounded text-center">{{ key }}: {{ value }}</div>
+    <div class="p-3 border rounded text-center">SL: {{ metrics.service_level }}</div>
   </div>
-  {% endfor %}
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">ASA: {{ metrics.asa }}</div>
+  </div>
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">Ocupación: {{ metrics.occupancy }}</div>
+  </div>
+  <div class="col-md-3">
+    <div class="p-3 border rounded text-center">Requeridos: {{ metrics.required_agents }}</div>
+  </div>
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend Erlang core with service level, ASA, occupancy and required agents helpers
- add full parameter form and results sections to Erlang template
- update apps blueprint to process new fields and calculation types
- test Erlang app with all parameters and expected metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f6abb5f248327a25eb6ce6e2e7807