### PR TITLE
Add data science dependencies and core analytics modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This project creates optimized work schedules using Flask.
    pip install -r requirements.txt
    ```
 
-   The list includes the `pulp` package used for solving the optimization problem.
+   Besides the `pulp` optimisation package the file now declares a set of
+   analytics libraries such as `pandas`, `numpy`, `seaborn`, `statsmodels`,
+   `pmdarima`, `scikit-learn`, `xgboost` and `plotly` which are required for
+   the predictive and time series modules.
 
 2. Copia el archivo `.env.example` a `.env` y completa las credenciales reales:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 flask==2.3.3
-pandas==2.0.3
-numpy==1.24.3
-matplotlib==3.7.2
-seaborn==0.12.2
+pandas==2.3.1
+numpy==2.3.2
+matplotlib==3.9.0
+seaborn==0.13.2
 openpyxl==3.1.2
 pulp==2.7.*
 psutil==5.9.5
@@ -11,6 +11,8 @@ python-dotenv==1.0.0
 Flask-WTF==1.2.2
 gunicorn==21.2.0
 plotly==5.18.0
-scipy==1.11.4
-statsmodels==0.14.1
-scikit-learn==1.3.2
+scipy==1.16.1
+statsmodels==0.14.5
+scikit-learn==1.7.1
+pmdarima==2.0.4
+xgboost==2.0.3

--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -9,7 +9,12 @@ from flask import Blueprint, redirect, render_template, request, url_for, sessio
 import json
 import plotly.graph_objects as go
 
-from ..other import timeseries_core, erlang_core
+from ..other import (
+    timeseries_core,
+    timeseries_full_core,
+    modelo_predictivo_core,
+    erlang_core,
+)
 
 bp = Blueprint("apps", __name__, url_prefix="/apps")
 

--- a/website/other/erlang_core.py
+++ b/website/other/erlang_core.py
@@ -7,7 +7,8 @@ JSON on the frontend.
 """
 from __future__ import annotations
 
-from typing import List, Dict, Any, Iterable
+from pathlib import Path
+from typing import IO, List, Dict, Any, Iterable
 
 import numpy as np
 import plotly.graph_objects as go
@@ -77,8 +78,8 @@ def load_demand_matrix(records: Iterable[Dict[str, Any]]) -> List[List[float]]:
     return matrix
 
 
-def load_demand_from_excel(file_stream) -> List[List[float]]:
-    """Load demand data from an Excel file-like object."""
+def load_demand_from_excel(file_stream: IO | str | Path) -> List[List[float]]:
+    """Load demand data from an Excel file-like object or path."""
     df = pd.read_excel(file_stream)
     return load_demand_matrix(df.to_dict("records"))
 

--- a/website/other/modelo_predictivo_core.py
+++ b/website/other/modelo_predictivo_core.py
@@ -1,0 +1,44 @@
+"""Predictive modelling utilities for demo purposes.
+
+This module groups together common data science imports so that other
+components can rely on a single place for lightweight experimentation.
+The implementations intentionally remain simple.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any
+
+import numpy as np
+import pandas as pd
+import seaborn as sns  # noqa: F401 - imported for convenience
+import statsmodels.api as sm
+
+try:  # pragma: no cover - optional dependency
+    import pmdarima as pm  # noqa: F401
+except Exception:  # pragma: no cover
+    pm = None  # type: ignore
+
+from sklearn.metrics import mean_squared_error  # noqa: F401
+from sklearn.model_selection import train_test_split  # noqa: F401
+
+try:  # pragma: no cover - optional dependency
+    from xgboost import XGBRegressor  # noqa: F401
+except Exception:  # pragma: no cover
+    XGBRegressor = None  # type: ignore
+
+import plotly.graph_objects as go
+
+
+def simple_forecast(series: Iterable[float]) -> Dict[str, Any]:
+    """Return a one-step forecast using a minimal ARIMA model."""
+    arr = np.array(list(series), dtype=float)
+    if arr.size == 0:
+        return {"forecast": [], "figure": go.Figure().to_dict()}
+
+    model = sm.tsa.ARIMA(arr, order=(1, 0, 0)).fit()
+    forecast = model.forecast(steps=1)
+
+    fig = go.Figure(data=[go.Scatter(y=arr, mode="lines", name="data")])
+    fig.add_trace(go.Scatter(x=[len(arr)], y=forecast.tolist(), mode="markers", name="forecast"))
+    fig.update_layout(title="Simple Forecast", xaxis_title="Index", yaxis_title="Value")
+    return {"forecast": forecast.tolist(), "figure": fig.to_dict()}

--- a/website/other/timeseries_full_core.py
+++ b/website/other/timeseries_full_core.py
@@ -1,0 +1,50 @@
+"""Extended time series utilities with forecasting helpers."""
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any
+
+import numpy as np
+import pandas as pd
+import seaborn as sns  # noqa: F401
+import statsmodels.api as sm
+
+try:  # pragma: no cover - optional dependency
+    import pmdarima as pm  # noqa: F401
+except Exception:  # pragma: no cover
+    pm = None  # type: ignore
+
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+
+try:  # pragma: no cover - optional dependency
+    from xgboost import XGBRegressor  # noqa: F401
+except Exception:  # pragma: no cover
+    XGBRegressor = None  # type: ignore
+
+import plotly.graph_objects as go
+
+
+def run_full_analysis(series: Iterable[float]) -> Dict[str, Any]:
+    """Return forecast metrics and a Plotly figure for ``series``."""
+    arr = np.array(list(series), dtype=float)
+    if arr.size < 5:
+        return {"metrics": {}, "figure": go.Figure().to_dict()}
+
+    train, test = train_test_split(arr, test_size=0.2, shuffle=False)
+    model = sm.tsa.ARIMA(train, order=(1, 0, 0)).fit()
+    forecast = model.forecast(steps=len(test))
+    mse = float(mean_squared_error(test, forecast))
+
+    fig = go.Figure(
+        data=[
+            go.Scatter(y=arr, mode="lines", name="data"),
+            go.Scatter(
+                x=np.arange(len(train), len(arr)),
+                y=forecast,
+                mode="lines",
+                name="forecast",
+            ),
+        ]
+    )
+    fig.update_layout(title="Full Time Series Forecast", xaxis_title="Index", yaxis_title="Value")
+    return {"metrics": {"mse": mse}, "figure": fig.to_dict()}


### PR DESCRIPTION
## Summary
- expand `requirements.txt` with modern data-science stack including pmdarima and xgboost
- introduce `modelo_predictivo_core` and `timeseries_full_core` with common analytics imports
- enhance existing cores and blueprints to support file paths and new modules
- document new dependencies in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f6ac25ca883278687abb1ec6c018d