### PR TITLE
chore: add analytics dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This project creates optimized work schedules using Flask.
    pip install -r requirements.txt
    ```
 
-   The list includes the `pulp` package used for solving the optimization problem.
+   Besides Flask the application relies on data-science libraries such as
+   **pandas**, **numpy**, **seaborn**, **statsmodels**, **pmdarima**,
+   **scikit-learn**, **xgboost** and **plotly** for the analytics demos.
+   The list also includes the `pulp` package used for solving the optimization
+   problem.
 
 2. Copia el archivo `.env.example` a `.env` y completa las credenciales reales:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ plotly==5.18.0
 scipy==1.11.4
 statsmodels==0.14.1
 scikit-learn==1.3.2
+pmdarima==2.0.3
+xgboost==2.0.3

--- a/website/other/modelo_predictivo_core.py
+++ b/website/other/modelo_predictivo_core.py
@@ -13,7 +13,28 @@ from io import BytesIO
 from typing import Any, Dict
 
 import pandas as pd
+import numpy as np
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
+
+# Optional imports used by extended forecasting strategies.  These libraries are
+# heavy and may not always be installed in minimal environments, therefore they
+# are loaded lazily and default to ``None`` when unavailable.
+try:  # pragma: no cover - optional dependency
+    from pmdarima import auto_arima
+except Exception:  # pragma: no cover - optional dependency
+    auto_arima = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from sklearn.ensemble import RandomForestRegressor
+except Exception:  # pragma: no cover - optional dependency
+    RandomForestRegressor = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from xgboost import XGBRegressor
+except Exception:  # pragma: no cover - optional dependency
+    XGBRegressor = None  # type: ignore
+
+_ = (np, auto_arima, RandomForestRegressor, XGBRegressor)
 
 
 def detectar_frecuencia(series: pd.Series) -> str:

--- a/website/other/timeseries_full_core.py
+++ b/website/other/timeseries_full_core.py
@@ -6,6 +6,12 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 from sklearn.metrics import mean_absolute_error, mean_squared_error
+import seaborn as sns
+
+# Establish a default theme so any seaborn-based charts elsewhere in the app use
+# a consistent style.  The heavy lifting in this module still relies on Plotly,
+# but importing seaborn here ensures the dependency is available and configured.
+sns.set_theme(style="whitegrid")
 
 
 def _preprocess(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- add optional forecasting libs and numpy to predictive core
- configure seaborn styling for time-series helper
- document analytics dependencies in README and requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f69b0474083278895bbe5c1ca66be