### PR TITLE
Add wide app layout with metric card styles

### DIFF
--- a/website/static/css/apps.css
+++ b/website/static/css/apps.css
@@ -1,3 +1,8 @@
+/* Wide layout for app pages */
+main.container-xxl {
+  max-width: 100%;
+}
+
 /* Layout for app metric cards */
 .metrics-grid {
   display: grid;
@@ -10,4 +15,21 @@
   flex-direction: column;
   justify-content: center;
   text-align: center;
+  padding: 1rem;
+  border-radius: .5rem;
+}
+
+.metric-card.success {
+  border: 1px solid #198754;
+  background: rgba(25, 135, 84, 0.15);
+}
+
+.metric-card.warning {
+  border: 1px solid #ffc107;
+  background: rgba(255, 193, 7, 0.15);
+}
+
+.metric-card.danger {
+  border: 1px solid #dc3545;
+  background: rgba(220, 53, 69, 0.15);
 }

--- a/website/templates/apps/layout.html
+++ b/website/templates/apps/layout.html
@@ -1,16 +1,11 @@
-{% extends 'base.html' %}
+{% extends '_layout.html' %}
 
 {% block content %}
-<nav class="navbar navbar-light bg-light mb-4">
-  <div class="container-fluid">
-    <span class="navbar-brand mb-0 h1">Apps</span>
-  </div>
-</nav>
 <div class="row">
   <aside class="col-md-3 col-lg-2 mb-4">
     <div class="list-group">
       <a href="{{ url_for('core.generador') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.generador' else '' }}">Generador</a>
-      <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint.startswith('apps.erlang') }}">Erlang</a>
+      <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint.startswith('apps.erlang') else '' }}">Erlang</a>
       <a href="{{ url_for('apps.kpis') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.kpis' else '' }}">KPIs</a>
       <a href="{{ url_for('apps.series') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint in ['apps.series', 'apps.timeseries'] else '' }}">Series</a>
       <a href="{{ url_for('apps.predictivo') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.predictivo' else '' }}">Predictivo</a>
@@ -21,3 +16,4 @@
   </div>
 </div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Add dedicated layout for app pages with sidebar navigation
- Provide wide layout and success/warning/danger metric card styles

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689f876b389c83278c34ca9d4397a31c