### PR TITLE
feat: add advanced erlang cx dimensioning view

### DIFF
--- a/website/templates/apps/erlang_cx.html
+++ b/website/templates/apps/erlang_cx.html
@@ -1,0 +1,143 @@
+{% extends 'apps/layout.html' %}
+
+{% block app_content %}
+<h2 class="fw-bold mb-4">Erlang CX</h2>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-4">
+        <label for="forecast" class="form-label">Forecast</label>
+        <input type="number" step="any" class="form-control" id="forecast" name="forecast" required>
+      </div>
+      <div class="col-md-4">
+        <label for="interval" class="form-label">Intervalo (seg)</label>
+        <input type="number" step="any" class="form-control" id="interval" name="interval" required>
+      </div>
+      <div class="col-md-4">
+        <label for="aht" class="form-label">AHT (seg)</label>
+        <input type="number" step="any" class="form-control" id="aht" name="aht" required>
+      </div>
+      <div class="col-md-4">
+        <label for="agents" class="form-label">Agentes</label>
+        <input type="number" class="form-control" id="agents" name="agents" required>
+      </div>
+      <div class="col-md-4">
+        <label for="awt" class="form-label">AWT (seg)</label>
+        <input type="number" step="any" class="form-control" id="awt" name="awt" required>
+      </div>
+      <div class="col-12">
+        <div class="form-check form-switch">
+          <input class="form-check-input" type="checkbox" id="use_advanced" name="use_advanced">
+          <label class="form-check-label" for="use_advanced">Parámetros avanzados</label>
+        </div>
+      </div>
+      <div id="advanced-fields" style="display:none;">
+        <div class="row g-3 mt-0">
+          <div class="col-md-6">
+            <label for="lines" class="form-label">Líneas</label>
+            <input type="number" class="form-control" id="lines" name="lines">
+          </div>
+          <div class="col-md-6">
+            <label for="patience" class="form-label">Patience (seg)</label>
+            <input type="number" step="any" class="form-control" id="patience" name="patience">
+          </div>
+        </div>
+      </div>
+      <div class="col-12">
+        <label for="target_sl" class="form-label">SL objetivo: <span id="sl-display">{{ (target_sl*100)|round(0) }}</span>%</label>
+        <input type="range" class="form-range" id="target_sl" name="target_sl" min="0.70" max="0.95" step="0.01" value="{{ target_sl }}">
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-primary">Calcular</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% if metrics %}
+<div class="row g-3 mb-4">
+  <div class="col-md-3">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title">SL %</h5>
+        <p class="card-text">{{ (metrics.service_level * 100) | round(2) }}</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title">ASA (s)</h5>
+        <p class="card-text">{{ metrics.asa | round(2) }}</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title">Ocupación %</h5>
+        <p class="card-text">{{ (metrics.occupancy * 100) | round(2) }}</p>
+      </div>
+    </div>
+  </div>
+  {% if metrics.abandonment is defined %}
+  <div class="col-md-3">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title">Abandonment %</h5>
+        <p class="card-text">{{ (metrics.abandonment * 100) | round(2) }}</p>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</div>
+
+<div class="mb-4">
+  <h3>Análisis de Dimensionamiento</h3>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Recomendados</th>
+        <th>Actuales</th>
+        <th>Diferencia</th>
+        <th>Calls/Agent</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{{ table.recommended }}</td>
+        <td>{{ table.current }}</td>
+        <td>{{ table.difference }}</td>
+        <td>{{ table.calls_per_agent | round(2) }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+{% if chart_json %}
+<div id="sensitivity-chart" class="mb-4"></div>
+<script>
+  var fig = {{ chart_json|safe }};
+  Plotly.react('sensitivity-chart', fig.data, fig.layout);
+</script>
+{% endif %}
+{% endif %}
+
+<script>
+const advToggle = document.getElementById('use_advanced');
+const advFields = document.getElementById('advanced-fields');
+function toggleAdv(){
+  advFields.style.display = advToggle.checked ? 'block' : 'none';
+}
+advToggle.addEventListener('change', toggleAdv);
+toggleAdv();
+const slInput = document.getElementById('target_sl');
+const slDisplay = document.getElementById('sl-display');
+if(slInput){
+  slInput.addEventListener('input', function(){ slDisplay.textContent = (this.value*100).toFixed(0); });
+}
+</script>
+
+{% endblock %}

--- a/website/templates/apps/layout.html
+++ b/website/templates/apps/layout.html
@@ -10,7 +10,8 @@
   <aside class="col-md-3 col-lg-2 mb-4">
     <div class="list-group">
       <a href="{{ url_for('core.generador') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.generador' else '' }}">Generador</a>
-      <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint.startswith('apps.erlang') }}">Erlang</a>
+      <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.erlang' else '' }}">Erlang</a>
+      <a href="{{ url_for('apps.erlang_cx') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.erlang_cx' else '' }}">Erlang CX</a>
       <a href="{{ url_for('apps.kpis') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.kpis' else '' }}">KPIs</a>
       <a href="{{ url_for('apps.series') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint in ['apps.series', 'apps.timeseries'] else '' }}">Series</a>
       <a href="{{ url_for('apps.predictivo') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.predictivo' else '' }}">Predictivo</a>


### PR DESCRIPTION
## Summary
- add `/apps/erlang_cx` view with advanced Erlang CX metrics and sensitivity chart
- include Erlang CX navigation link
- create template with form, metric cards, dimensioning analysis and Plotly graph

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -q flask==2.3.3 pandas==2.0.3 numpy==1.24.3 plotly==5.18.0 Flask-WTF==1.2.2 requests==2.31.0 python-dotenv==1.0.0` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_689f876e5a948327ab9910243089d9f7