### PR TITLE
Add interactive Erlang visualisation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import sys, types
+
+# Stub heavy optional modules to keep tests lightweight
+ts_core = types.SimpleNamespace()
+def _ts_run(params, file_storage=None):
+    return {
+        'metrics': {'demo': 1},
+        'recommendation': 'ok',
+        'weekly_table': [{'semana_iso': 1, 'planificados': 1, 'reales': 1, 'desvio_abs': 0, 'desvio_pct': 0}],
+        'heatmap': {},
+        'interactive': {},
+    }
+ts_core.run = _ts_run
+sys.modules.setdefault('website.other.timeseries_core', ts_core)
+
+mp_core = types.SimpleNamespace()
+def _mp_run(file, steps):
+    return {
+        'metrics': {'mae': 0.0},
+        'table': [{'a': 1}],
+        'file_bytes': b'dummy'
+    }
+mp_core.run = _mp_run
+sys.modules.setdefault('website.other.modelo_predictivo_core', mp_core)
+
+sys.modules.setdefault('website.other.timeseries_full_core', types.SimpleNamespace())

--- a/tests/test_apps_erlang.py
+++ b/tests/test_apps_erlang.py
@@ -101,3 +101,18 @@ def test_erlang_subroute_authenticated():
     login(client)
     response = client.get('/apps/erlang/demo')
     assert response.status_code == 200
+
+
+def test_erlang_visual_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/erlang/visual')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_erlang_visual_authenticated():
+    client = app.test_client()
+    login(client)
+    response = client.get('/apps/erlang/visual')
+    assert response.status_code == 200
+    assert b'Erlang Visual' in response.data

--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -58,6 +58,12 @@ def erlang():
     return render_template("apps/erlang.html", metrics=metrics)
 
 
+@bp.route("/erlang/visual")
+def erlang_visual():
+    """Render interactive Erlang visualisation."""
+    return render_template("apps/erlang_visual.html")
+
+
 @bp.route("/predictivo", methods=["GET", "POST"])
 def predictivo():
     """Execute the predictive model workflow."""

--- a/website/static/js/erlang_visual.js
+++ b/website/static/js/erlang_visual.js
@@ -1,0 +1,156 @@
+(function(){
+  let calls = 100;
+  let aht = 30; // seconds
+  let agents = 10;
+  const awt = 20; // target wait
+  const slTarget = 0.8;
+
+  function erlangB(traffic, agents){
+    if(agents === 0) return 1.0;
+    if(traffic === 0) return 0.0;
+    let b = 1.0;
+    for(let i=1;i<=agents;i++){
+      b = (traffic*b)/(i + traffic*b);
+    }
+    return b;
+  }
+
+  function erlangC(traffic, agents){
+    if(agents <= traffic) return 1.0;
+    const eb = erlangB(traffic, agents);
+    const rho = traffic/agents;
+    if(rho >= 1) return 1.0;
+    return eb / (1 - rho + rho*eb);
+  }
+
+  function serviceLevel(arrival, aht, agents, awt){
+    const traffic = arrival*aht;
+    if(agents <= traffic) return 0.0;
+    const pc = erlangC(traffic, agents);
+    if(pc === 0) return 1.0;
+    const expFactor = Math.exp(-(agents - traffic)*awt/aht);
+    return 1 - pc*expFactor;
+  }
+
+  function waitingTime(arrival, aht, agents){
+    const traffic = arrival*aht;
+    if(agents <= traffic) return Infinity;
+    const pc = erlangC(traffic, agents);
+    return (pc*aht)/(agents - traffic);
+  }
+
+  function occupancy(arrival, aht, agents){
+    const traffic = arrival*aht;
+    if(agents <= 0) return 1.0;
+    return Math.min(traffic/agents, 1.0);
+  }
+
+  function requiredAgents(arrival, aht, awt, slTarget, maxAgents){
+    for(let a=1;a<=maxAgents;a++){
+      if(serviceLevel(arrival, aht, a, awt) >= slTarget) return a;
+    }
+    return maxAgents;
+  }
+
+  function renderService(sl){
+    document.getElementById('service-level').textContent = (sl*100).toFixed(1)+'%';
+  }
+
+  function renderASA(asa){
+    const bar = document.getElementById('asa-bar');
+    const max = 120; // seconds
+    const pct = Math.min(asa/max,1)*100;
+    bar.style.width = pct+'%';
+    bar.textContent = (asa === Infinity ? '∞' : asa.toFixed(1)+'s');
+  }
+
+  function renderBars(busy, available, waiting){
+    const totalAgents = busy + available;
+    const busyPct = totalAgents ? (busy/totalAgents)*100 : 0;
+    const availPct = totalAgents ? (available/totalAgents)*100 : 0;
+    const waitPct = (waiting/(waiting+totalAgents))*100;
+    const busyBar = document.getElementById('busy-bar');
+    const availBar = document.getElementById('available-bar');
+    const waitBar = document.getElementById('waiting-bar');
+    busyBar.style.width = busyPct+'%';
+    busyBar.textContent = `${busy}`;
+    availBar.style.width = availPct+'%';
+    availBar.textContent = `${available}`;
+    waitBar.style.width = waitPct+'%';
+    waitBar.textContent = `${waiting}`;
+  }
+
+  function renderMatrix(busy, available, vacant){
+    const container = document.getElementById('agents-matrix');
+    container.innerHTML='';
+    for(let i=0;i<busy;i++){
+      const div=document.createElement('div');
+      div.className='agent busy';
+      container.appendChild(div);
+    }
+    for(let i=0;i<available;i++){
+      const div=document.createElement('div');
+      div.className='agent available';
+      container.appendChild(div);
+    }
+    for(let i=0;i<vacant;i++){
+      const div=document.createElement('div');
+      div.className='agent vacant';
+      container.appendChild(div);
+    }
+  }
+
+  function renderQueue(len, asa){
+    const container = document.getElementById('queue');
+    container.innerHTML='';
+    for(let i=0;i<len;i++){
+      const span=document.createElement('span');
+      span.className='queue-item';
+      span.textContent='📞';
+      const time=document.createElement('small');
+      time.textContent=`${asa.toFixed(0)}s`;
+      span.appendChild(time);
+      container.appendChild(span);
+    }
+    if(len>0){
+      const info=document.createElement('span');
+      info.className='ms-2';
+      info.textContent=`${len} en cola`;
+      container.appendChild(info);
+    }
+  }
+
+  function update(){
+    const arrival = calls/3600;
+    const traffic = arrival*aht;
+    const sl = serviceLevel(arrival, aht, agents, awt);
+    const asa = waitingTime(arrival, aht, agents);
+    const occ = occupancy(arrival, aht, agents);
+    const required = requiredAgents(arrival, aht, awt, slTarget, 200);
+    const busy = Math.min(agents, Math.round(occ*agents));
+    const available = Math.max(0, agents - busy);
+    const vacant = Math.max(0, required - agents);
+    const queueProb = erlangC(traffic, agents);
+    const queued = Math.max(0, Math.round(queueProb*calls) - busy);
+    renderService(sl);
+    renderASA(asa);
+    renderBars(busy, available, queued);
+    renderMatrix(busy, available, vacant);
+    renderQueue(queued, asa);
+  }
+
+  document.getElementById('btn-demand').addEventListener('click', function(){
+    calls += Math.round(calls*0.1) || 1;
+    update();
+  });
+  document.getElementById('btn-agents').addEventListener('click', function(){
+    agents += 5;
+    update();
+  });
+  document.getElementById('btn-aht').addEventListener('click', function(){
+    aht = Math.max(5, aht-5);
+    update();
+  });
+
+  update();
+})();

--- a/website/templates/apps/erlang_visual.html
+++ b/website/templates/apps/erlang_visual.html
@@ -1,0 +1,64 @@
+{% extends 'apps/layout.html' %}
+
+{% block app_content %}
+<h2 class="fw-bold mb-4">Erlang Visual</h2>
+<div class="mb-3">
+  <button id="btn-demand" class="btn btn-primary me-2">Aumentar demanda</button>
+  <button id="btn-agents" class="btn btn-secondary me-2">Agregar 5 agentes</button>
+  <button id="btn-aht" class="btn btn-secondary">Reducir AHT</button>
+</div>
+
+<div class="row mb-4">
+  <div class="col-md-4 text-center">
+    <div id="service-circle" class="rounded-circle border d-flex align-items-center justify-content-center mx-auto mb-2" style="width:120px;height:120px;">
+      <span id="service-level" class="fw-bold">0%</span>
+    </div>
+    <small>Nivel de Servicio</small>
+  </div>
+  <div class="col-md-8">
+    <label class="form-label">ASA</label>
+    <div class="progress" style="height:30px;">
+      <div id="asa-bar" class="progress-bar" role="progressbar" style="width:0%">0s</div>
+    </div>
+  </div>
+</div>
+
+<div class="mb-4">
+  <h5>Matriz de agentes</h5>
+  <div id="agents-matrix" class="d-flex flex-wrap" style="max-width:300px;"></div>
+</div>
+
+<div class="mb-4">
+  <h5>Cola</h5>
+  <div id="queue" class="d-flex align-items-end"></div>
+</div>
+
+<div class="mb-2">
+  <label>Ocupados</label>
+  <div class="progress" style="height:25px;">
+    <div id="busy-bar" class="progress-bar bg-success" role="progressbar" style="width:0%">0</div>
+  </div>
+</div>
+<div class="mb-2">
+  <label>Disponibles</label>
+  <div class="progress" style="height:25px;">
+    <div id="available-bar" class="progress-bar bg-danger" role="progressbar" style="width:0%">0</div>
+  </div>
+</div>
+<div class="mb-4">
+  <label>Esperando</label>
+  <div class="progress" style="height:25px;">
+    <div id="waiting-bar" class="progress-bar bg-secondary" role="progressbar" style="width:0%">0</div>
+  </div>
+</div>
+
+<style>
+  #agents-matrix .agent { width:20px; height:20px; margin:2px; border-radius:4px; }
+  #agents-matrix .busy { background-color:#28a745; }
+  #agents-matrix .available { background-color:#dc3545; }
+  #agents-matrix .vacant { background-color:#6c757d; }
+  #queue .queue-item { font-size:24px; margin-right:4px; }
+</style>
+
+<script src="{{ url_for('static', filename='js/erlang_visual.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `erlang_visual` route and template for dynamic Erlang simulation
- implement client-side queue and agent matrix with controls
- add tests and lightweight stubs for heavy modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f876fcb048327b9a0aa51c46bfe54