### PR TITLE
Add blending calculator app with sensitivity analysis

### DIFF
--- a/tests/test_apps_blending.py
+++ b/tests/test_apps_blending.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.utils.kpis_core', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_blending_requires_login():
+    client = app.test_client()
+    response = client.get('/apps/blending')
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/login')
+
+
+def test_blending_authenticated_get():
+    client = app.test_client()
+    login(client)
+    response = client.get('/apps/blending')
+    assert response.status_code == 200
+    assert b'blending-form' in response.data
+
+
+def test_blending_post_calculates(monkeypatch):
+    from website.other import blending_core
+
+    def fake_calc(*args, **kwargs):
+        return {
+            'service_level': 0.9,
+            'outbound_capacity': 15.0,
+            'optimal_threshold': 2,
+            'figure': '{}',
+        }
+
+    monkeypatch.setattr(blending_core, 'calculate_blending_metrics', fake_calc)
+
+    client = app.test_client()
+    login(client)
+    token = _csrf_token(client, '/apps/blending')
+    response = client.post(
+        '/apps/blending',
+        data={
+            'forecast': '100',
+            'aht': '30',
+            'agents': '10',
+            'awt': '20',
+            'lines': '10',
+            'patience': '100',
+            'threshold': '2',
+            'csrf_token': token,
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'SLA Inbound' in html
+    assert 'Capacidad Outbound' in html
+    assert 'Threshold Óptimo' in html

--- a/website/other/blending_core.py
+++ b/website/other/blending_core.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Dict, Any, List
+
+import plotly.graph_objects as go
+
+from .erlang_core import service_level_erlang_c, occupancy_erlang_c
+
+
+def calculate_blending_metrics(
+    forecast: float,
+    aht: float,
+    agents: int,
+    awt: float,
+    lines: int,
+    patience: float,
+    threshold: int,
+) -> Dict[str, Any]:
+    """Compute blending metrics and sensitivity figure.
+
+    Parameters
+    ----------
+    forecast: float
+        Forecasted inbound calls for an hour.
+    aht: float
+        Average handle time in seconds.
+    agents: int
+        Total available agents.
+    awt: float
+        Service level threshold (seconds).
+    lines: int
+        Unused parameter for compatibility.
+    patience: float
+        Unused parameter for compatibility.
+    threshold: int
+        Agents reserved for outbound work.
+    """
+    interval = 3600.0
+    arrival_rate = forecast / interval if interval else 0.0
+
+    available_agents = max(0, agents - threshold)
+    sla = service_level_erlang_c(arrival_rate, aht, available_agents, awt)
+    occupancy = occupancy_erlang_c(arrival_rate, aht, available_agents)
+
+    inbound_traffic = arrival_rate * aht
+    outbound_agents = max(0.0, agents - threshold - inbound_traffic)
+    outbound_capacity = outbound_agents * interval / aht if aht else 0.0
+
+    optimal_threshold = 0
+    best_capacity = -1.0
+    for t in range(0, agents + 1):
+        avail = max(0, agents - t)
+        sl = service_level_erlang_c(arrival_rate, aht, avail, awt)
+        if sl >= 0.8:  # maintain 80% SLA
+            out_agents = max(0.0, agents - t - inbound_traffic)
+            cap = out_agents * interval / aht if aht else 0.0
+            if cap > best_capacity:
+                best_capacity = cap
+                optimal_threshold = t
+
+    threshold_range: List[int] = list(range(0, min(agents, int(agents * 0.4)) + 1))
+    sl_data: List[float] = []
+    out_data: List[float] = []
+    for t in threshold_range:
+        avail = max(0, agents - t)
+        sl_val = service_level_erlang_c(arrival_rate, aht, avail, awt)
+        out_agents = max(0.0, agents - t - inbound_traffic)
+        out_cap = out_agents * interval / aht if aht else 0.0
+        sl_data.append(sl_val)
+        out_data.append(out_cap)
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=threshold_range,
+            y=sl_data,
+            mode="lines+markers",
+            name="Service Level Inbound",
+            yaxis="y",
+            line=dict(color="blue"),
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=threshold_range,
+            y=out_data,
+            mode="lines+markers",
+            name="Capacidad Outbound",
+            yaxis="y2",
+            line=dict(color="green"),
+        )
+    )
+    fig.update_layout(
+        title="Service Level vs Capacidad Outbound por Threshold",
+        xaxis_title="Threshold (Agentes Reservados)",
+        yaxis=dict(title="Service Level Inbound", side="left", range=[0, 1]),
+        yaxis2=dict(
+            title="Capacidad Outbound (llamadas/hora)",
+            side="right",
+            overlaying="y",
+        ),
+        hovermode="x unified",
+    )
+    if threshold in threshold_range:
+        fig.add_vline(x=threshold, line_dash="dash", line_color="red", annotation_text="Actual")
+    if optimal_threshold in threshold_range:
+        fig.add_vline(
+            x=optimal_threshold,
+            line_dash="dash",
+            line_color="orange",
+            annotation_text="Óptimo",
+        )
+
+    return {
+        "service_level": sla,
+        "outbound_capacity": outbound_capacity,
+        "occupancy": occupancy,
+        "optimal_threshold": optimal_threshold,
+        "figure": fig.to_json(),
+    }

--- a/website/templates/apps/blending.html
+++ b/website/templates/apps/blending.html
@@ -1,0 +1,75 @@
+{% extends 'apps/layout.html' %}
+
+{% block app_content %}
+<h2 class="fw-bold mb-4">Blending</h2>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <form id="blending-form" class="row g-3" method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-4">
+        <label for="forecast" class="form-label">Forecast</label>
+        <input type="number" class="form-control" id="forecast" name="forecast" required>
+      </div>
+      <div class="col-md-4">
+        <label for="aht" class="form-label">AHT (seg)</label>
+        <input type="number" class="form-control" id="aht" name="aht" required>
+      </div>
+      <div class="col-md-4">
+        <label for="agents" class="form-label">Agentes</label>
+        <input type="number" class="form-control" id="agents" name="agents" required>
+      </div>
+      <div class="col-md-4">
+        <label for="awt" class="form-label">AWT (seg)</label>
+        <input type="number" class="form-control" id="awt" name="awt" required>
+      </div>
+      <div class="col-md-4">
+        <label for="lines" class="form-label">Líneas</label>
+        <input type="number" class="form-control" id="lines" name="lines" required>
+      </div>
+      <div class="col-md-4">
+        <label for="patience" class="form-label">Patience (seg)</label>
+        <input type="number" class="form-control" id="patience" name="patience" required>
+      </div>
+      <div class="col-md-4">
+        <label for="threshold" class="form-label">Threshold (agentes)</label>
+        <input type="number" class="form-control" id="threshold" name="threshold" required>
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Calcular</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% if metrics %}
+<div class="row g-3 mb-4" id="blending-metrics">
+  <div class="col-md-4">
+    <div class="p-3 border rounded text-center">SLA Inbound: {{ metrics.service_level }}</div>
+  </div>
+  <div class="col-md-4">
+    <div class="p-3 border rounded text-center">Capacidad Outbound: {{ metrics.outbound_capacity }}</div>
+  </div>
+  <div class="col-md-4">
+    <div class="p-3 border rounded text-center">Threshold Óptimo: {{ metrics.optimal_threshold }}</div>
+  </div>
+</div>
+{% endif %}
+
+{% if figure_json %}
+<div class="card mb-4">
+  <div class="card-body">
+    <div id="blending-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
+  </div>
+</div>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script>
+  (function(){
+    const el = document.getElementById('blending-figure');
+    const fig = JSON.parse(el.dataset.figure);
+    Plotly.react(el, fig.data, fig.layout);
+  })();
+</script>
+{% endif %}
+
+{% endblock %}

--- a/website/templates/apps/layout.html
+++ b/website/templates/apps/layout.html
@@ -11,6 +11,7 @@
     <div class="list-group">
       <a href="{{ url_for('core.generador') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.generador' else '' }}">Generador</a>
       <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint.startswith('apps.erlang') }}">Erlang</a>
+      <a href="{{ url_for('apps.blending') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.blending' else '' }}">Blending</a>
       <a href="{{ url_for('apps.kpis') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.kpis' else '' }}">KPIs</a>
       <a href="{{ url_for('apps.series') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint in ['apps.series', 'apps.timeseries'] else '' }}">Series</a>
       <a href="{{ url_for('apps.predictivo') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.predictivo' else '' }}">Predictivo</a>


### PR DESCRIPTION
## Summary
- add new blending calculator core module
- expose `/apps/blending` route with Plotly sensitivity graph
- include navigation link and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f87718f848327941a81c14b36d39c