### PR TITLE
feat: improve metric card layout

### DIFF
--- a/website/static/css/apps.css
+++ b/website/static/css/apps.css
@@ -1,13 +1,53 @@
 /* Layout for app metric cards */
 .metrics-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(12, 1fr);
   gap: 1rem;
 }
 
+/* Default: span full width; adjust at breakpoints for 2 and 4 column cuts */
 .metric-card {
+  background-color: #f0f2f6;
+  padding: 1rem;
+  border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   text-align: center;
+  min-height: 100px;
+  grid-column: span 12;
+}
+
+.metric-card .small {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (min-width: 576px) {
+  .metric-card { grid-column: span 6; }
+}
+
+@media (min-width: 768px) {
+  .metric-card { grid-column: span 4; }
+}
+
+@media (min-width: 992px) {
+  .metric-card { grid-column: span 2; }
+}
+
+/* Status colors mirroring original app */
+.metric-card.success {
+  background-color: #d4edda;
+  border-left: 4px solid #28a745;
+}
+
+.metric-card.warning {
+  background-color: #fff3cd;
+  border-left: 4px solid #ffc107;
+}
+
+.metric-card.danger {
+  background-color: #f8d7da;
+  border-left: 4px solid #dc3545;
 }

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -15,48 +15,36 @@
 
   <!-- KPIs -->
   {% if resultado and resultado.metrics %}
-  <div class="row g-3 mb-4 text-center">
-    <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-body h-100 stat-card">
-        <div class="small text-muted">Total Agentes</div>
-        <div class="h4 mb-0">{{ resultado.metrics.total_agents or 0 }}</div>
+  <div class="metrics-grid mb-4 text-center">
+    <div class="metric-card">
+      <div class="small text-muted">Total Agentes</div>
+      <div class="h4 mb-0">{{ resultado.metrics.total_agents or 0 }}</div>
+    </div>
+    <div class="metric-card">
+      <div class="small text-muted">Full Time</div>
+      <div class="h4 mb-0">{{ resultado.metrics.ft_agents or 0 }}</div>
+    </div>
+    <div class="metric-card">
+      <div class="small text-muted">Part Time</div>
+      <div class="h4 mb-0">{{ resultado.metrics.pt_agents or 0 }}</div>
+    </div>
+    <div class="metric-card">
+      <div class="small text-muted">Cobertura Real</div>
+      <div class="h4 mb-0">
+        {% if resultado.metrics.coverage_percentage is not none %}
+          {{ '%.1f'|format(resultado.metrics.coverage_percentage) }}%
+        {% else %}
+          0%
+        {% endif %}
       </div>
     </div>
-    <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-body h-100 stat-card">
-        <div class="small text-muted">Full Time</div>
-        <div class="h4 mb-0">{{ resultado.metrics.ft_agents or 0 }}</div>
-      </div>
+    <div class="metric-card">
+      <div class="small text-muted">Exceso</div>
+      <div class="h4 mb-0">{{ resultado.metrics.overstaffing or 0 }}</div>
     </div>
-    <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-body h-100 stat-card">
-        <div class="small text-muted">Part Time</div>
-        <div class="h4 mb-0">{{ resultado.metrics.pt_agents or 0 }}</div>
-      </div>
-    </div>
-    <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-body h-100 stat-card">
-        <div class="small text-muted">Cobertura Real</div>
-        <div class="h4 mb-0">
-          {% if resultado.metrics.coverage_percentage is not none %}
-            {{ '%.1f'|format(resultado.metrics.coverage_percentage) }}%
-          {% else %}
-            0%
-          {% endif %}
-        </div>
-      </div>
-    </div>
-    <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-body h-100 stat-card">
-        <div class="small text-muted">Exceso</div>
-        <div class="h4 mb-0">{{ resultado.metrics.overstaffing or 0 }}</div>
-      </div>
-    </div>
-    <div class="col-6 col-md-4 col-lg-2">
-      <div class="card card-body h-100 stat-card">
-        <div class="small text-muted">Déficit</div>
-        <div class="h4 mb-0">{{ resultado.metrics.understaffing or 0 }}</div>
-      </div>
+    <div class="metric-card">
+      <div class="small text-muted">Déficit</div>
+      <div class="h4 mb-0">{{ resultado.metrics.understaffing or 0 }}</div>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- add color-coded metric card variants and responsive grid
- restructure resultados KPIs to use new metric cards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8776e7108327ade9ce374d39a85f