### PR TITLE
feat: enable ajax contact form

### DIFF
--- a/tests/test_contacto_route.py
+++ b/tests/test_contacto_route.py
@@ -3,9 +3,13 @@ import sys
 import types
 
 import pytest
+import re
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.other.timeseries_core', types.SimpleNamespace())
+sys.modules.setdefault('website.other.erlang_core', types.SimpleNamespace())
+sys.modules.setdefault('website.other.modelo_predictivo_core', types.SimpleNamespace())
 
 from website import create_app
 from website.utils import allowlist as allowlist_module
@@ -24,4 +28,23 @@ def test_contacto_route():
     response = client.get('/contacto')
     assert response.status_code == 200
     assert b'Contacto' in response.data
+
+
+def _csrf_token(client):
+    resp = client.get('/contacto')
+    html = resp.get_data(as_text=True)
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+def test_contacto_htmx_post():
+    client = app.test_client()
+    token = _csrf_token(client)
+    response = client.post(
+        '/contacto',
+        data={'name': 'Tester', 'csrf_token': token},
+        headers={'HX-Request': 'true'},
+    )
+    assert response.status_code == 200
+    assert b'Gracias' in response.data
 

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -331,8 +331,14 @@ def configuracion():
     return render_template("configuracion.html")
 
 
-@bp.route("/contacto")
+@bp.route("/contacto", methods=["GET", "POST"])
 def contacto():
+    if request.method == "POST":
+        nombre = request.form.get("name", "amigo")
+        context = {"nombre": nombre}
+        if request.headers.get("HX-Request"):
+            return render_template("partials/contacto_response.html", **context)
+        return render_template("contacto.html", mensaje=True, **context)
     return render_template("contacto.html")
 
 

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -61,6 +61,7 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </body>
 </html>

--- a/website/templates/contacto.html
+++ b/website/templates/contacto.html
@@ -4,21 +4,36 @@
 <h1>Contacto</h1>
 <p class="mb-4">¿Tienes preguntas? Envíanos un mensaje y te responderemos pronto.</p>
 
-<form method="post" class="mb-4">
+<form
+  method="post"
+  action="{{ url_for('core.contacto') }}"
+  class="mb-4"
+  hx-post="{{ url_for('core.contacto') }}"
+  hx-target="#contacto-response"
+  hx-swap="innerHTML"
+>
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="name" class="form-label">Nombre</label>
-    <input type="text" class="form-control" id="name" placeholder="Tu nombre">
+    <input type="text" class="form-control" id="name" name="name" placeholder="Tu nombre">
   </div>
   <div class="mb-3">
     <label for="email" class="form-label">Correo</label>
-    <input type="email" class="form-control" id="email" placeholder="nombre@ejemplo.com">
+    <input type="email" class="form-control" id="email" name="email" placeholder="nombre@ejemplo.com">
   </div>
   <div class="mb-3">
     <label for="message" class="form-label">Mensaje</label>
-    <textarea class="form-control" id="message" rows="4" placeholder="¿En qué podemos ayudarte?"></textarea>
+    <textarea class="form-control" id="message" name="message" rows="4" placeholder="¿En qué podemos ayudarte?"></textarea>
   </div>
   <button type="submit" class="btn btn-primary">Enviar</button>
 </form>
+
+<div id="contacto-response">
+  {% if mensaje %}
+  <div class="alert alert-success" role="alert">
+    ¡Gracias, {{ nombre }}! Hemos recibido tu mensaje.
+  </div>
+  {% endif %}
+</div>
 {% endblock %}
 

--- a/website/templates/partials/contacto_response.html
+++ b/website/templates/partials/contacto_response.html
@@ -1,0 +1,4 @@
+<div class="alert alert-success" role="alert">
+  ¡Gracias, {{ nombre }}! Hemos recibido tu mensaje.
+</div>
+


### PR DESCRIPTION
## Summary
- add htmx library and progressive enhancement for contact form
- handle contact POST requests with partial HTML responses
- test htmx submission workflow

## Testing
- `pytest tests/test_contacto_route.py`

------
https://chatgpt.com/codex/tasks/task_e_689f87777e1c832788e43f8be266532d