### PR TITLE
Add Erlang sensitivity chart with vertical reference lines

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -33,6 +33,7 @@ def erlang():
     """Render a minimal Erlang calculator."""
 
     metrics = {}
+    figure_json = None
 
     if request.method == "POST":
         calls = request.form.get("calls", type=float, default=0) or 0.0
@@ -45,7 +46,7 @@ def erlang():
 
         sl_target = sl / 100 if sl > 1 else sl
 
-        metrics = erlang_core.calculate_erlang_metrics(
+        result = erlang_core.calculate_erlang_metrics(
             calls=calls,
             aht=aht,
             sl_target=sl_target,
@@ -55,7 +56,15 @@ def erlang():
             calc_type=calc_type,
         )
 
-    return render_template("apps/erlang.html", metrics=metrics)
+        if isinstance(result, dict):
+            fig = result.pop("figure", None)
+            metrics = result
+            if isinstance(fig, go.Figure):
+                figure_json = fig.to_json()
+            elif fig is not None:
+                figure_json = json.dumps(fig)
+
+    return render_template("apps/erlang.html", metrics=metrics, figure_json=figure_json)
 
 
 @bp.route("/predictivo", methods=["GET", "POST"])

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -61,4 +61,22 @@
   </div>
 </div>
 {% endif %}
+
+{% if figure_json %}
+<div class="card mb-4">
+  <div class="card-body">
+    <div id="erlang-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
+  </div>
+</div>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script>
+  (function(){
+    const el = document.getElementById('erlang-figure');
+    if (el) {
+      const fig = JSON.parse(el.dataset.figure);
+      Plotly.react(el, fig.data, fig.layout);
+    }
+  })();
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- generate Plotly sensitivity figure for Erlang metrics with vertical 'Actual' and 'Recomendado' markers
- serialize figure to JSON and render it on the Erlang page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689f8777e1a4832797888ab3f69a9845