### PR TITLE
Serve Predictivo results via Flask endpoint

### DIFF
--- a/website/templates/apps/predictivo.html
+++ b/website/templates/apps/predictivo.html
@@ -55,8 +55,8 @@
         </tbody>
       </table>
     </div>
-    {% if download %}
-    <a id="predictivo-download" class="btn btn-secondary mt-3" href="data:application/octet-stream;base64,{{ download }}" download="resultados.csv">Descargar Resultados</a>
+    {% if download_url %}
+    <a id="predictivo-download" class="btn btn-secondary mt-3" href="{{ download_url }}">Descargar Resultados</a>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Replace base64 download hack with server-side endpoint for Predictivo forecasts
- Add `/apps/predictivo/download/<job_id>` using `send_file` and temp cleanup
- Adjust Predictivo template and add test for download behavior

## Testing
- `pip install -r requirements.txt` *(failed: numpy build error on Python 3.12)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689f8779407c83279920f1505f7f40d6