### PR TITLE
Fix blueprint for predictivo download route

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -116,7 +116,7 @@ def predictivo():
     )
 
 
-@bp.route("/predictivo/download/<job_id>")
+@apps_bp.route("/predictivo/download/<job_id>")
 def predictivo_download(job_id: str):
     """Serve the generated forecast file and remove it afterwards."""
 


### PR DESCRIPTION
## Summary
- correct predictivo download route to use `apps_bp`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_wtf')*

------
https://chatgpt.com/codex/tasks/task_e_689f92c62e68832795b1022a74b96ef1