### PR TITLE
Add Apps dropdown to navbar

### DIFF
--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -6,6 +6,34 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('plotly', types.SimpleNamespace(graph_objects=types.SimpleNamespace(Figure=object)))
+sys.modules.setdefault('plotly.graph_objects', sys.modules['plotly'].graph_objects)
+sys.modules.setdefault('website.other.timeseries_core', types.SimpleNamespace())
+sys.modules.setdefault('website.other.erlang_core', types.SimpleNamespace())
+sys.modules.setdefault('website.other.modelo_predictivo_core', types.SimpleNamespace())
+sys.modules.setdefault('website.utils.kpis_core', types.SimpleNamespace())
+
+from flask import Blueprint
+
+_apps_bp = Blueprint("apps", __name__, url_prefix="/apps")
+
+@_apps_bp.route("/erlang")
+def erlang():
+    return ""
+
+@_apps_bp.route("/timeseries")
+def timeseries():
+    return ""
+
+@_apps_bp.route("/predictivo")
+def predictivo():
+    return ""
+
+@_apps_bp.route("/kpis")
+def kpis():
+    return ""
+
+sys.modules.setdefault('website.blueprints.apps', types.SimpleNamespace(apps_bp=_apps_bp))
 
 from website import create_app
 from website.utils import allowlist as allowlist_module
@@ -45,5 +73,7 @@ def test_nav_links_authenticated():
     assert response.status_code == 200
     html = response.get_data(as_text=True)
     assert '/apps/erlang' in html
+    assert 'Apps</a>' in html
     assert '/apps/timeseries' in html
     assert '/apps/predictivo' in html
+    assert '/apps/kpis' in html

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -35,9 +35,15 @@
             <li class="nav-item"><a href="{{ url_for('core.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generador' else '' }}">Generador</a></li>
             <li class="nav-item"><a href="{{ url_for('core.resultados') }}" class="nav-link {{ 'active' if request.endpoint=='resultados' else '' }}">Resultados</a></li>
             <li class="nav-item"><a href="{{ url_for('core.configuracion') }}" class="nav-link {{ 'active' if request.endpoint=='configuracion' else '' }}">Configuración</a></li>
-            <li class="nav-item"><a href="{{ url_for('apps.erlang') }}" class="nav-link {{ 'active' if request.endpoint=='apps.erlang' else '' }}">Erlang</a></li>
-            <li class="nav-item"><a href="{{ url_for('apps.timeseries') }}" class="nav-link {{ 'active' if request.endpoint=='apps.timeseries' else '' }}">Series</a></li>
-            <li class="nav-item"><a href="{{ url_for('apps.predictivo') }}" class="nav-link {{ 'active' if request.endpoint=='apps.predictivo' else '' }}">Predictivo</a></li>
+            <li class="nav-item dropdown">
+              <a href="{{ url_for('apps.erlang') }}" class="nav-link dropdown-toggle {{ 'active' if request.endpoint and request.endpoint.startswith('apps.') else '' }}" id="appsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Apps</a>
+              <ul class="dropdown-menu">
+                <li><a class="dropdown-item" href="{{ url_for('apps.erlang') }}">Erlang</a></li>
+                <li><a class="dropdown-item" href="{{ url_for('apps.timeseries') }}">Series</a></li>
+                <li><a class="dropdown-item" href="{{ url_for('apps.predictivo') }}">Predictivo</a></li>
+                <li><a class="dropdown-item" href="{{ url_for('apps.kpis') }}">KPIs</a></li>
+              </ul>
+            </li>
           </ul>
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">
             <i class="bi bi-moon" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- group app links under new "Apps" dropdown and include KPIs link
- expand navigation tests to cover "Apps" dropdown

## Testing
- `pytest tests/test_navigation_links.py`

------
https://chatgpt.com/codex/tasks/task_e_689f92c7b85083278ffc6bc79211fb2a