### PR TITLE
Add demo app routes and supporting services

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -11,6 +11,8 @@ import tempfile
 import uuid
 from typing import Any, Dict
 
+import pandas as pd
+
 import plotly.graph_objects as go
 from flask import (
     Blueprint,
@@ -24,7 +26,16 @@ from flask import (
     after_this_request,
 )
 
-from ..other import timeseries_core, erlang_core, modelo_predictivo_core
+from ..other import (
+    timeseries_core,
+    erlang_core,
+    modelo_predictivo_core,
+    erlang_visual,
+    comparativo_core,
+    staffing_core,
+    batch_core,
+)
+from ..services import erlang as erlang_service, erlang_o
 
 # Public blueprint used by the main application factory
 apps_bp = Blueprint("apps", __name__, url_prefix="/apps")
@@ -202,6 +213,296 @@ def series():
 def erlang_submodule(submodule: str):
     """Dispatch any Erlang submodule to the main view."""
     return erlang()
+
+
+@apps_bp.route("/erlang_visual", methods=["GET", "POST"])
+def erlang_visual_view():
+    """Enhanced Erlang view with agent visualisation."""
+
+    metrics: Dict[str, Any] = {}
+    figure_json = None
+
+    if request.method == "POST":
+        forecast = request.form.get("forecast", type=float, default=0.0) or 0.0
+        aht = request.form.get("aht", type=float, default=0.0) or 0.0
+        agents = request.form.get("agents", type=int, default=0) or 0
+        awt = request.form.get("awt", type=float, default=0.0) or 0.0
+        interval = request.form.get("interval", default="3600")
+        interval_seconds = 1800 if interval == "1800" else 3600
+        sl_target = request.form.get("sl_target", type=float, default=0.8)
+
+        arrival_rate = forecast / interval_seconds
+        sl = erlang_service.sla_x(arrival_rate, aht, agents, awt)
+        asa = erlang_service.waiting_time_erlang_c(arrival_rate, aht, agents)
+        occ = erlang_core.occupancy_erlang_c(arrival_rate, aht, agents)
+        required = erlang_service.agents_for_sla(sl_target, arrival_rate, aht, awt)
+        hourly_forecast = forecast * 3600 / interval_seconds if interval_seconds else 0
+        cpa = hourly_forecast / agents if agents else 0
+
+        fig = erlang_visual.create_agent_visualization(
+            forecast, aht, agents, awt, interval_seconds, int(required)
+        )
+        figure_json = fig.to_json()
+
+        metrics = {
+            "service_level": f"{sl:.1%}",
+            "asa": f"{asa:.1f}",
+            "occupancy": f"{occ:.1%}",
+            "required_agents": int(required),
+            "calls_per_agent": f"{cpa:.1f}",
+        }
+
+        if request.headers.get("HX-Request"):
+            return render_template(
+                "partials/erlang_visual_results.html",
+                metrics=metrics,
+                figure_json=figure_json,
+            )
+
+    return render_template(
+        "apps/erlang_visual.html", metrics=metrics, figure_json=figure_json
+    )
+
+
+@apps_bp.route("/chat", methods=["GET", "POST"])
+def chat():
+    """Chat multi-channel calculator."""
+
+    metrics: Dict[str, Any] = {}
+
+    if request.method == "POST":
+        forecast = request.form.get("forecast", type=float, default=0.0) or 0.0
+        ahts_raw = request.form.get("ahts", "")
+        agents = request.form.get("agents", type=int, default=0) or 0
+        awt = request.form.get("awt", type=float, default=0.0) or 0.0
+        interval = request.form.get("interval", default="3600")
+        interval_seconds = 1800 if interval == "1800" else 3600
+        sl_target = request.form.get("sl_target", type=float, default=0.8)
+
+        try:
+            aht_list = [float(x) for x in ahts_raw.split(",") if x.strip()]
+        except ValueError:
+            aht_list = []
+        if not aht_list:
+            aht_list = [ahts_raw and float(ahts_raw) or 0.0]
+
+        arrival_rate = forecast / interval_seconds
+        sl = erlang_service.chat_sla(arrival_rate, aht_list, agents, awt)
+        asa = erlang_service.chat_asa(arrival_rate, aht_list, agents)
+        required = erlang_service.chat_agents_for_sla(
+            sl_target, arrival_rate, aht_list, awt
+        )
+
+        metrics = {
+            "service_level": f"{sl:.1%}",
+            "asa": f"{asa:.1f}",
+            "required_agents": int(required),
+        }
+
+        if request.headers.get("HX-Request"):
+            return render_template("partials/chat_results.html", metrics=metrics)
+
+    return render_template("apps/chat.html", metrics=metrics)
+
+
+@apps_bp.route("/blending", methods=["GET", "POST"])
+def blending():
+    """Blending calculator."""
+
+    metrics: Dict[str, Any] = {}
+
+    if request.method == "POST":
+        forecast = request.form.get("forecast", type=float, default=0.0) or 0.0
+        aht = request.form.get("aht", type=float, default=0.0) or 0.0
+        agents = request.form.get("agents", type=int, default=0) or 0
+        awt = request.form.get("awt", type=float, default=0.0) or 0.0
+        threshold = request.form.get("threshold", type=float, default=0.0) or 0.0
+        interval = request.form.get("interval", default="3600")
+        interval_seconds = 1800 if interval == "1800" else 3600
+        sl_target = request.form.get("sl_target", type=float, default=0.8)
+
+        arrival_rate = forecast / interval_seconds
+        sl = erlang_service.bl_sla(
+            arrival_rate, aht, agents, awt, None, None, threshold
+        )
+        optimal = erlang_service.bl_optimal_threshold(
+            arrival_rate, aht, agents, awt, None, None, sl_target
+        )
+        metrics = {
+            "service_level": f"{sl:.1%}",
+            "optimal_threshold": f"{optimal:.1f}",
+        }
+
+        if request.headers.get("HX-Request"):
+            return render_template("partials/blending_results.html", metrics=metrics)
+
+    return render_template("apps/blending.html", metrics=metrics)
+
+
+@apps_bp.route("/erlang_o", methods=["GET", "POST"])
+def erlang_o_view():
+    """Erlang O outbound calculator."""
+
+    metrics: Dict[str, Any] = {}
+
+    if request.method == "POST":
+        agents = request.form.get("agents", type=int, default=0) or 0
+        hours_per_day = request.form.get("hours_per_day", type=float, default=0.0) or 0.0
+        calls_per_hour = request.form.get("calls_per_hour", type=float, default=0.0) or 0.0
+        success_rate = request.form.get("success_rate", type=float, default=0.3) or 0.3
+        metrics = erlang_o.productivity(agents, hours_per_day, calls_per_hour, success_rate)
+
+        if request.headers.get("HX-Request"):
+            return render_template("partials/erlang_o_results.html", metrics=metrics)
+
+    return render_template("apps/erlang_o.html", metrics=metrics)
+
+
+@apps_bp.route("/comparativo", methods=["GET", "POST"])
+def comparativo():
+    """Run comparative analysis across models."""
+
+    table = []
+    figure_json = None
+
+    if request.method == "POST":
+        forecast = request.form.get("forecast", type=float, default=0.0) or 0.0
+        aht = request.form.get("aht", type=float, default=0.0) or 0.0
+        agents = request.form.get("agents", type=int, default=0) or 0
+        awt = request.form.get("awt", type=float, default=0.0) or 0.0
+        lines = request.form.get("lines", type=int, default=agents) or agents
+        patience = request.form.get("patience", type=float, default=180.0) or 180.0
+        interval = request.form.get("interval", default="3600")
+        interval_seconds = 1800 if interval == "1800" else 3600
+
+        result = comparativo_core.comparative_analysis(
+            forecast, interval_seconds, aht, agents, awt, lines, patience
+        )
+        table = result.get("table", [])
+        fig = result.get("figure")
+        if isinstance(fig, dict):
+            figure_json = json.dumps(fig)
+        elif isinstance(fig, go.Figure):
+            figure_json = fig.to_json()
+
+        if request.headers.get("HX-Request"):
+            return render_template(
+                "partials/comparativo_results.html", table=table, figure_json=figure_json
+            )
+
+    return render_template(
+        "apps/comparativo.html", table=table, figure_json=figure_json
+    )
+
+
+@apps_bp.route("/staffing", methods=["GET", "POST"])
+def staffing():
+    """Staffing optimisation utility."""
+
+    table = []
+    figure_json = None
+    summary = {}
+
+    if request.method == "POST":
+        forecasts_raw = request.form.get("forecasts", "")
+        try:
+            forecasts = [float(x) for x in forecasts_raw.split(",") if x.strip()]
+        except ValueError:
+            forecasts = []
+        aht = request.form.get("aht", type=float, default=0.0) or 0.0
+        interval = request.form.get("interval", default="3600")
+        interval_seconds = 1800 if interval == "1800" else 3600
+        sl_target = request.form.get("sl_target", type=float, default=0.8)
+
+        result = staffing_core.staffing_optimizer(
+            forecasts, aht, interval_seconds, sl_target
+        )
+        table = result.get("table", [])
+        summary = result.get("summary", {})
+        fig = result.get("figure")
+        if isinstance(fig, dict):
+            figure_json = json.dumps(fig)
+        elif isinstance(fig, go.Figure):
+            figure_json = fig.to_json()
+
+        if request.headers.get("HX-Request"):
+            return render_template(
+                "partials/staffing_results.html",
+                table=table,
+                summary=summary,
+                figure_json=figure_json,
+            )
+
+    return render_template(
+        "apps/staffing.html", table=table, summary=summary, figure_json=figure_json
+    )
+
+
+@apps_bp.route("/batch", methods=["GET", "POST"])
+def batch():
+    """Batch processing of contact centre scenarios."""
+
+    table = []
+    download_url = None
+
+    if request.method == "POST":
+        file = request.files.get("file")
+        sl_target = request.form.get("sl_target", type=float, default=0.8)
+        awt = request.form.get("awt", type=float, default=20.0)
+        interval_choice = request.form.get("interval", default="3600")
+        interval_seconds = 1800 if interval_choice == "1800" else 3600
+        default_channel = request.form.get("default_channel", "Llamadas")
+        if file:
+            if file.filename.endswith(".csv"):
+                df = pd.read_csv(file)
+            else:
+                df = pd.read_excel(file)
+            processed_rows = []
+            for _, row in df.iterrows():
+                metrics = batch_core.process_batch_row(
+                    row, sl_target, awt, interval_seconds, default_channel
+                )
+                processed_rows.append({**row, **metrics})
+            result_df = pd.DataFrame(processed_rows)
+            table = result_df.to_dict("records")
+            csv_bytes = batch_core.export_results(result_df).to_csv(index=False).encode("utf-8")
+            job_id = uuid.uuid4().hex
+            path = os.path.join(temp_dir, f"{job_id}.csv")
+            with open(path, "wb") as f:
+                f.write(csv_bytes)
+            download_url = url_for("apps.batch_download", job_id=job_id)
+
+        if request.headers.get("HX-Request"):
+            return render_template(
+                "partials/batch_results.html", table=table, download_url=download_url
+            )
+
+    return render_template(
+        "apps/batch.html", table=table, download_url=download_url
+    )
+
+
+@apps_bp.route("/batch/download/<job_id>")
+def batch_download(job_id: str):
+    """Send processed batch results."""
+    path = os.path.join(temp_dir, f"{job_id}.csv")
+    if not os.path.exists(path):
+        abort(404)
+
+    @after_this_request
+    def cleanup(response):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        return response
+
+    return send_file(
+        path,
+        as_attachment=True,
+        download_name="batch_result.csv",
+        mimetype="text/csv",
+    )
 
 
 @apps_bp.route("/kpis", methods=["GET", "POST"])

--- a/website/other/batch_core.py
+++ b/website/other/batch_core.py
@@ -1,0 +1,78 @@
+"""Batch processing utilities for Erlang calculations."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+import numpy as np
+import pandas as pd
+
+from ..services.erlang import (
+    service_level_erlang_c,
+    waiting_time_erlang_c,
+    agents_for_sla,
+    chat_sla,
+    chat_asa,
+    chat_agents_for_sla,
+)
+from .erlang_core import occupancy_erlang_c
+
+
+def process_batch_row(
+    row: pd.Series,
+    sl_target: float,
+    awt: float,
+    interval_seconds: int,
+    default_channel: str,
+) -> Dict[str, Any]:
+    """Compute metrics for a single batch row."""
+    seconds = row.get("Intervalo_Segundos", interval_seconds)
+    channel = str(row.get("Tipo_Canal", default_channel)).strip().title()
+    if channel not in ["Llamadas", "Chat"]:
+        channel = "Llamadas"
+    arrival_rate = row["Contactos"] / seconds
+    if channel == "Chat":
+        aht_list = [row["AHT"]]
+        sl = chat_sla(arrival_rate, aht_list, row["Agentes_Actuales"], awt)
+        asa = chat_asa(arrival_rate, aht_list, row["Agentes_Actuales"])
+        occupancy = occupancy_erlang_c(arrival_rate, row["AHT"], row["Agentes_Actuales"])
+        agents_req = chat_agents_for_sla(sl_target, arrival_rate, aht_list, awt)
+        agents_req_ceil = int(np.ceil(agents_req))
+        sl_req = sl_target
+        asa_req = chat_asa(arrival_rate, aht_list, agents_req_ceil)
+        occupancy_req = occupancy_erlang_c(arrival_rate, row["AHT"], agents_req_ceil)
+    else:
+        sl = service_level_erlang_c(arrival_rate, row["AHT"], row["Agentes_Actuales"], awt)
+        asa = waiting_time_erlang_c(arrival_rate, row["AHT"], row["Agentes_Actuales"])
+        occupancy = occupancy_erlang_c(arrival_rate, row["AHT"], row["Agentes_Actuales"])
+        agents_req = agents_for_sla(sl_target, arrival_rate, row["AHT"], awt)
+        agents_req_ceil = int(np.ceil(agents_req))
+        sl_req = sl_target
+        asa_req = waiting_time_erlang_c(arrival_rate, row["AHT"], agents_req_ceil)
+        occupancy_req = occupancy_erlang_c(arrival_rate, row["AHT"], agents_req_ceil)
+    diff_agents = agents_req - row["Agentes_Actuales"]
+    return {
+        "SL": sl,
+        "ASA": asa,
+        "Ocupacion": occupancy,
+        "Agentes_Requeridos": agents_req,
+        "SL_Requerido": sl_req,
+        "ASA_Requerido": asa_req,
+        "Ocupacion_Requerido": occupancy_req,
+        "Diferencia_Agentes": diff_agents,
+        "Tipo_Canal": channel,
+    }
+
+
+def export_results(df_processed: pd.DataFrame) -> pd.DataFrame:
+    """Return dataframe with status and recommendation columns."""
+    df_exp = df_processed.copy()
+    df_exp["Status_SL"] = np.where(df_exp["SL"] >= df_exp["SL_Requerido"], "OK", "BAJO")
+    df_exp["Recomendacion"] = np.where(
+        df_exp["Diferencia_Agentes"] > 0,
+        "Agregar " + df_exp["Diferencia_Agentes"].astype(str),
+        "Mantener",
+    )
+    return df_exp
+
+
+__all__ = ["process_batch_row", "export_results"]

--- a/website/other/comparativo_core.py
+++ b/website/other/comparativo_core.py
@@ -1,0 +1,89 @@
+"""Comparative analysis utilities."""
+from __future__ import annotations
+
+from typing import Dict, Any, List
+
+import plotly.express as px
+
+from ..services.erlang import (
+    service_level_erlang_c,
+    waiting_time_erlang_c,
+    sla_x,
+    chat_sla,
+    chat_asa,
+    bl_sla,
+    bl_outbound_capacity,
+)
+
+
+def comparative_analysis(
+    forecast: float,
+    interval_seconds: int,
+    aht: float,
+    agents: int,
+    awt: float,
+    lines: int,
+    patience: float,
+) -> Dict[str, Any]:
+    """Return metrics comparing multiple Erlang models."""
+    arrival_rate = forecast / interval_seconds
+
+    sl_basic = service_level_erlang_c(arrival_rate, aht, agents, awt)
+    asa_basic = waiting_time_erlang_c(arrival_rate, aht, agents)
+    occ_basic = arrival_rate * aht / agents if agents else 0.0
+
+    sl_abandon = sla_x(arrival_rate, aht, agents, awt, lines, patience)
+
+    chat_aht = [aht * 0.7, aht * 0.8, aht * 0.9]
+    sl_chat = chat_sla(arrival_rate, chat_aht, agents, awt)
+    asa_chat = chat_asa(arrival_rate, chat_aht, agents)
+
+    threshold = 3
+    sl_blend = bl_sla(arrival_rate, aht, agents, awt, lines, patience, threshold)
+    outbound_cap = bl_outbound_capacity(
+        arrival_rate, aht, agents, lines, patience, threshold, aht
+    )
+
+    table: List[Dict[str, Any]] = [
+        {
+            "Modelo": "Erlang C",
+            "Service Level": f"{sl_basic:.1%}",
+            "ASA": f"{asa_basic:.1f}",
+            "Ocupacion": f"{occ_basic:.1%}",
+            "Características": "Modelo básico, sin abandonment",
+        },
+        {
+            "Modelo": "Erlang X",
+            "Service Level": f"{sl_abandon:.1%}",
+            "ASA": f"{asa_basic:.1f}",
+            "Ocupacion": f"{occ_basic:.1%}",
+            "Características": "Con abandonment",
+        },
+        {
+            "Modelo": "Chat Multi-canal",
+            "Service Level": f"{sl_chat:.1%}",
+            "ASA": f"{asa_chat:.1f}",
+            "Ocupacion": f"{occ_basic:.1%}",
+            "Características": f"Multi-chat ({len(chat_aht)} simultáneos)",
+        },
+        {
+            "Modelo": "Blending",
+            "Service Level": f"{sl_blend:.1%}",
+            "ASA": f"{asa_basic:.1f}",
+            "Ocupacion": f"{occ_basic:.1%}",
+            "Características": f"Outbound: {outbound_cap:.0f} llamadas/h",
+        },
+    ]
+
+    fig = px.bar(
+        x=[row["Modelo"] for row in table],
+        y=[sl_basic, sl_abandon, sl_chat, sl_blend],
+        labels={"x": "Modelo", "y": "Service Level"},
+        title="Comparación de Service Level por Modelo",
+    )
+    fig.add_hline(y=0.8, line_dash="dash", line_color="red")
+
+    return {"table": table, "figure": fig.to_dict()}
+
+
+__all__ = ["comparative_analysis"]

--- a/website/other/erlang_visual.py
+++ b/website/other/erlang_visual.py
@@ -1,0 +1,154 @@
+"""Visual helpers for Erlang calculators."""
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import plotly.graph_objects as go
+
+from .erlang_core import (
+    service_level_erlang_c,
+    waiting_time_erlang_c,
+    occupancy_erlang_c,
+)
+
+# Visual constants replicated from the Streamlit version
+BUSY_COLOR = "#EF476F"
+AVAILABLE_COLOR = "#06D6A0"
+QUEUE_SHORT_COLOR = "#06D6A0"
+QUEUE_MED_COLOR = "#FFD166"
+QUEUE_LONG_COLOR = "#EF476F"
+
+BUSY_ICON = "📞"
+AVAILABLE_ICONS = ["👨‍💼", "👩‍💼"]
+QUEUE_ICON = "🧑‍🤝‍🧑"
+PLACEHOLDER_ICON = "❔"
+PLACEHOLDER_COLOR = "#B0BEC5"
+
+
+def create_agent_visualization(
+    forecast: float,
+    aht: float,
+    agents: int,
+    awt: float,
+    interval_seconds: int = 3600,
+    required_agents: Optional[int] = None,
+) -> go.Figure:
+    """Return Plotly figure with agent states and queue simulation."""
+    arrival_rate = forecast / interval_seconds
+    sl = service_level_erlang_c(arrival_rate, aht, agents, awt)
+    asa = waiting_time_erlang_c(arrival_rate, aht, agents)
+    occupancy = occupancy_erlang_c(arrival_rate, aht, agents)
+
+    agents_per_row = 10
+    display_agents = max(agents, required_agents or agents)
+    rows = math.ceil(display_agents / agents_per_row)
+
+    base_y = 1
+    queue_y = 0
+    metrics_y = base_y + rows + 1
+
+    fig = go.Figure()
+
+    busy_agents = int(agents * occupancy)
+    available_agents = agents - busy_agents
+    placeholder_agents = (
+        max(0, (required_agents or agents) - agents)
+        if required_agents is not None
+        else 0
+    )
+    agent_states = (
+        ["busy"] * busy_agents
+        + ["available"] * available_agents
+        + ["missing"] * placeholder_agents
+    )
+
+    fig.add_annotation(
+        x=agents_per_row * 1.2 / 2,
+        y=base_y + rows + 0.6,
+        text=f"{busy_agents}/{agents} agentes ocupados",
+        showarrow=False,
+        font=dict(size=12),
+    )
+
+    agent_x = []
+    agent_y = []
+    agent_icons = []
+    agent_colors = []
+    avail_index = 0
+
+    for i, state in enumerate(agent_states):
+        row = i // agents_per_row
+        col = i % agents_per_row
+        x = col * 1.2
+        y = base_y + rows - row - 1
+        agent_x.append(x)
+        agent_y.append(y)
+        if state == "busy":
+            agent_icons.append(BUSY_ICON)
+            agent_colors.append(BUSY_COLOR)
+        elif state == "available":
+            agent_icons.append(AVAILABLE_ICONS[avail_index % len(AVAILABLE_ICONS)])
+            avail_index += 1
+            agent_colors.append(AVAILABLE_COLOR)
+        else:
+            agent_icons.append(PLACEHOLDER_ICON)
+            agent_colors.append(PLACEHOLDER_COLOR)
+
+    fig.add_trace(
+        go.Scatter(
+            x=agent_x,
+            y=agent_y,
+            mode="text",
+            text=agent_icons,
+            textfont=dict(size=20, color=agent_colors),
+            showlegend=False,
+        )
+    )
+
+    queue_length = max(0, int((1 - sl) * forecast))
+    queue_colors = (
+        QUEUE_SHORT_COLOR if queue_length < 3 else QUEUE_MED_COLOR if queue_length < 6 else QUEUE_LONG_COLOR
+    )
+    queue_icons = [QUEUE_ICON] * queue_length
+    fig.add_trace(
+        go.Scatter(
+            x=list(range(queue_length)),
+            y=[queue_y] * queue_length,
+            mode="text",
+            text=queue_icons,
+            textfont=dict(size=16, color=queue_colors),
+            showlegend=False,
+        )
+    )
+
+    fig.add_annotation(
+        x=agents_per_row * 1.2 / 2,
+        y=metrics_y,
+        text=f"SL {sl:.1%} | ASA {asa:.1f}s | OCC {occupancy:.1%}",
+        showarrow=False,
+    )
+
+    fig.update_layout(
+        xaxis=dict(visible=False),
+        yaxis=dict(visible=False),
+        height=200 + rows * 30,
+        margin=dict(l=10, r=10, t=10, b=10),
+    )
+
+    return fig
+
+
+__all__ = [
+    "create_agent_visualization",
+    "BUSY_COLOR",
+    "AVAILABLE_COLOR",
+    "QUEUE_SHORT_COLOR",
+    "QUEUE_MED_COLOR",
+    "QUEUE_LONG_COLOR",
+    "BUSY_ICON",
+    "AVAILABLE_ICONS",
+    "QUEUE_ICON",
+    "PLACEHOLDER_ICON",
+    "PLACEHOLDER_COLOR",
+]

--- a/website/other/staffing_core.py
+++ b/website/other/staffing_core.py
@@ -1,0 +1,61 @@
+"""Staffing optimisation helpers."""
+from __future__ import annotations
+
+from typing import Dict, Any, Iterable, List
+
+import plotly.graph_objects as go
+
+from ..services.erlang import service_level_erlang_c, waiting_time_erlang_c, agents_for_sla
+
+
+def staffing_optimizer(
+    forecasts: Iterable[float],
+    aht: float,
+    interval_seconds: int,
+    sl_target: float,
+    awt: float = 20.0,
+) -> Dict[str, Any]:
+    """Return per-hour staffing recommendations."""
+    hours = list(range(len(list(forecasts))))
+    forecasts = list(forecasts)
+    table: List[Dict[str, Any]] = []
+    total_agent_hours = 0
+    agent_series: List[float] = []
+
+    for hour, forecast in zip(hours, forecasts):
+        arrival_rate = forecast / interval_seconds
+        agents_needed = agents_for_sla(sl_target, arrival_rate, aht, awt)
+        sl = service_level_erlang_c(arrival_rate, aht, agents_needed, awt)
+        asa = waiting_time_erlang_c(arrival_rate, aht, agents_needed)
+        table.append(
+            {
+                "Hora": f"{hour:02d}:00",
+                "Forecast": round(forecast, 2),
+                "Agentes": agents_needed,
+                "SL": round(sl, 3),
+                "ASA": round(asa, 2),
+            }
+        )
+        total_agent_hours += agents_needed
+        agent_series.append(agents_needed)
+
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=hours, y=forecasts, name="Forecast"))
+    fig.add_trace(go.Scatter(x=hours, y=agent_series, name="Agentes"))
+    fig.update_layout(
+        title="Forecast vs Agentes Necesarios",
+        xaxis_title="Hora",
+        yaxis_title="Cantidad",
+    )
+
+    summary = {
+        "max_agents": max(agent_series) if agent_series else 0,
+        "min_agents": min(agent_series) if agent_series else 0,
+        "avg_agents": total_agent_hours / len(agent_series) if agent_series else 0,
+        "total_agent_hours": total_agent_hours,
+    }
+
+    return {"table": table, "figure": fig.to_dict(), "summary": summary}
+
+
+__all__ = ["staffing_optimizer"]

--- a/website/services/erlang_o.py
+++ b/website/services/erlang_o.py
@@ -1,0 +1,44 @@
+"""Utilities for Erlang O (outbound) calculations."""
+from __future__ import annotations
+
+import math
+
+
+def productivity(agents: int, hours_per_day: float, calls_per_hour: float, success_rate: float = 0.3) -> dict:
+    """Return productivity metrics for outbound campaigns."""
+    total_calls = agents * hours_per_day * calls_per_hour
+    successful_calls = total_calls * success_rate
+    return {
+        "total_calls": total_calls,
+        "successful_calls": successful_calls,
+        "success_rate": success_rate,
+        "calls_per_agent_day": hours_per_day * calls_per_hour,
+        "successful_per_agent_day": hours_per_day * calls_per_hour * success_rate,
+    }
+
+
+def agents_for_target(
+    target_calls_day: float,
+    hours_per_day: float,
+    calls_per_hour: float,
+    success_rate: float = 0.3,
+) -> int:
+    """Return agents required to hit a target of successful calls per day."""
+    calls_per_agent_day = hours_per_day * calls_per_hour * success_rate
+    if calls_per_agent_day <= 0:
+        return 0
+    return math.ceil(target_calls_day / calls_per_agent_day)
+
+
+def dialer_ratio(
+    answer_rate: float = 0.25,
+    agent_talk_time: float = 5.0,
+    wait_between_calls: float = 2.0,
+) -> float:
+    """Return recommended predictive dialer ratio."""
+    cycle_time = agent_talk_time + wait_between_calls
+    ratio = cycle_time / (agent_talk_time * answer_rate)
+    return max(1.0, ratio)
+
+
+__all__ = ["productivity", "agents_for_target", "dialer_ratio"]

--- a/website/templates/apps/batch.html
+++ b/website/templates/apps/batch.html
@@ -1,0 +1,20 @@
+{% extends 'apps/layout.html' %}
+{% block app_content %}
+<h2 class="fw-bold mb-4">Batch Processor</h2>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" enctype="multipart/form-data" hx-post="{{ url_for('apps.batch') }}" hx-target="#batch-results" hx-swap="innerHTML" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-4"><label class="form-label">Archivo</label><input type="file" name="file" class="form-control"></div>
+      <div class="col-md-2"><label class="form-label">SL Objetivo</label><input type="number" step="any" name="sl_target" class="form-control" value="0.8"></div>
+      <div class="col-md-2"><label class="form-label">AWT (seg)</label><input type="number" step="any" name="awt" class="form-control" value="20"></div>
+      <div class="col-md-2"><label class="form-label">Intervalo</label><select name="interval" class="form-select"><option value="1800">30 minutos</option><option value="3600" selected>1 hora</option></select></div>
+      <div class="col-md-2"><label class="form-label">Canal por defecto</label><select name="default_channel" class="form-select"><option value="Llamadas">Llamadas</option><option value="Chat">Chat</option></select></div>
+      <div class="col-12"><button class="btn btn-primary" type="submit">Procesar</button></div>
+    </form>
+  </div>
+</div>
+<div id="batch-results">
+  {% include 'partials/batch_results.html' %}
+</div>
+{% endblock %}

--- a/website/templates/apps/blending.html
+++ b/website/templates/apps/blending.html
@@ -1,0 +1,48 @@
+{% extends 'apps/layout.html' %}
+{% block app_content %}
+<h2 class="fw-bold mb-4">Blending</h2>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" hx-post="{{ url_for('apps.blending') }}" hx-target="#blending-results" hx-swap="innerHTML" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-4">
+        <label class="form-label">Forecast</label>
+        <input type="number" step="any" name="forecast" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">AHT (seg)</label>
+        <input type="number" step="any" name="aht" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Agentes</label>
+        <input type="number" name="agents" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">AWT (seg)</label>
+        <input type="number" step="any" name="awt" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Threshold</label>
+        <input type="number" step="any" name="threshold" class="form-control" value="0">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Intervalo</label>
+        <select name="interval" class="form-select">
+          <option value="1800">30 minutos</option>
+          <option value="3600" selected>1 hora</option>
+        </select>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">SL Objetivo</label>
+        <input type="number" step="any" name="sl_target" class="form-control" value="0.8">
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Calcular</button>
+      </div>
+    </form>
+  </div>
+</div>
+<div id="blending-results">
+  {% include 'partials/blending_results.html' %}
+</div>
+{% endblock %}

--- a/website/templates/apps/chat.html
+++ b/website/templates/apps/chat.html
@@ -1,0 +1,44 @@
+{% extends 'apps/layout.html' %}
+{% block app_content %}
+<h2 class="fw-bold mb-4">Chat</h2>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" hx-post="{{ url_for('apps.chat') }}" hx-target="#chat-results" hx-swap="innerHTML" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-4">
+        <label class="form-label">Chats por intervalo</label>
+        <input type="number" step="any" name="forecast" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">AHTs (coma separados)</label>
+        <input type="text" name="ahts" class="form-control" placeholder="120,150">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Agentes</label>
+        <input type="number" name="agents" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">AWT (seg)</label>
+        <input type="number" step="any" name="awt" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Intervalo</label>
+        <select name="interval" class="form-select">
+          <option value="1800">30 minutos</option>
+          <option value="3600" selected>1 hora</option>
+        </select>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">SL Objetivo</label>
+        <input type="number" step="any" name="sl_target" class="form-control" value="0.8">
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Calcular</button>
+      </div>
+    </form>
+  </div>
+</div>
+<div id="chat-results">
+  {% include 'partials/chat_results.html' %}
+</div>
+{% endblock %}

--- a/website/templates/apps/comparativo.html
+++ b/website/templates/apps/comparativo.html
@@ -1,0 +1,22 @@
+{% extends 'apps/layout.html' %}
+{% block app_content %}
+<h2 class="fw-bold mb-4">Análisis Comparativo</h2>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" hx-post="{{ url_for('apps.comparativo') }}" hx-target="#comparativo-results" hx-swap="innerHTML" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-3"><label class="form-label">Forecast</label><input type="number" step="any" name="forecast" class="form-control" required></div>
+      <div class="col-md-3"><label class="form-label">AHT (seg)</label><input type="number" step="any" name="aht" class="form-control" required></div>
+      <div class="col-md-3"><label class="form-label">Agentes</label><input type="number" name="agents" class="form-control" required></div>
+      <div class="col-md-3"><label class="form-label">AWT (seg)</label><input type="number" step="any" name="awt" class="form-control" required></div>
+      <div class="col-md-3"><label class="form-label">Líneas</label><input type="number" name="lines" class="form-control" required></div>
+      <div class="col-md-3"><label class="form-label">Patience (seg)</label><input type="number" step="any" name="patience" class="form-control" value="180"></div>
+      <div class="col-md-3"><label class="form-label">Intervalo</label><select name="interval" class="form-select"><option value="1800">30 minutos</option><option value="3600" selected>1 hora</option></select></div>
+      <div class="col-12"><button class="btn btn-primary" type="submit">Calcular</button></div>
+    </form>
+  </div>
+</div>
+<div id="comparativo-results">
+  {% include 'partials/comparativo_results.html' %}
+</div>
+{% endblock %}

--- a/website/templates/apps/erlang_o.html
+++ b/website/templates/apps/erlang_o.html
@@ -1,0 +1,33 @@
+{% extends 'apps/layout.html' %}
+{% block app_content %}
+<h2 class="fw-bold mb-4">Erlang O</h2>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" hx-post="{{ url_for('apps.erlang_o_view') }}" hx-target="#erlang-o-results" hx-swap="innerHTML" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-3">
+        <label class="form-label">Agentes</label>
+        <input type="number" name="agents" class="form-control" required>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Horas/día</label>
+        <input type="number" step="any" name="hours_per_day" class="form-control" required>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Llamadas/hora</label>
+        <input type="number" step="any" name="calls_per_hour" class="form-control" required>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Tasa de éxito</label>
+        <input type="number" step="any" name="success_rate" class="form-control" value="0.3">
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Calcular</button>
+      </div>
+    </form>
+  </div>
+</div>
+<div id="erlang-o-results">
+  {% include 'partials/erlang_o_results.html' %}
+</div>
+{% endblock %}

--- a/website/templates/apps/erlang_visual.html
+++ b/website/templates/apps/erlang_visual.html
@@ -1,0 +1,44 @@
+{% extends 'apps/layout.html' %}
+{% block app_content %}
+<h2 class="fw-bold mb-4">Erlang Visual</h2>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" hx-post="{{ url_for('apps.erlang_visual_view') }}" hx-target="#erlang-visual-results" hx-swap="innerHTML" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-4">
+        <label class="form-label">Forecast</label>
+        <input type="number" step="any" name="forecast" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">AHT (seg)</label>
+        <input type="number" step="any" name="aht" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Agentes</label>
+        <input type="number" name="agents" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">AWT (seg)</label>
+        <input type="number" step="any" name="awt" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Intervalo</label>
+        <select name="interval" class="form-select">
+          <option value="1800">30 minutos</option>
+          <option value="3600" selected>1 hora</option>
+        </select>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">SL Objetivo</label>
+        <input type="number" step="any" name="sl_target" class="form-control" value="0.8">
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary" type="submit">Calcular</button>
+      </div>
+    </form>
+  </div>
+</div>
+<div id="erlang-visual-results">
+  {% include 'partials/erlang_visual_results.html' %}
+</div>
+{% endblock %}

--- a/website/templates/apps/staffing.html
+++ b/website/templates/apps/staffing.html
@@ -1,0 +1,19 @@
+{% extends 'apps/layout.html' %}
+{% block app_content %}
+<h2 class="fw-bold mb-4">Staffing</h2>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" hx-post="{{ url_for('apps.staffing') }}" hx-target="#staffing-results" hx-swap="innerHTML" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-6"><label class="form-label">Forecasts por hora (coma separados)</label><input type="text" name="forecasts" class="form-control" placeholder="100,120,140"></div>
+      <div class="col-md-3"><label class="form-label">AHT (seg)</label><input type="number" step="any" name="aht" class="form-control" required></div>
+      <div class="col-md-3"><label class="form-label">Intervalo</label><select name="interval" class="form-select"><option value="1800">30 minutos</option><option value="3600" selected>1 hora</option></select></div>
+      <div class="col-md-3"><label class="form-label">SL Objetivo</label><input type="number" step="any" name="sl_target" class="form-control" value="0.8"></div>
+      <div class="col-12"><button class="btn btn-primary" type="submit">Calcular</button></div>
+    </form>
+  </div>
+</div>
+<div id="staffing-results">
+  {% include 'partials/staffing_results.html' %}
+</div>
+{% endblock %}

--- a/website/templates/partials/batch_results.html
+++ b/website/templates/partials/batch_results.html
@@ -1,0 +1,13 @@
+{% if table %}
+<table class="table table-bordered mb-3">
+  <thead><tr>{% for k in table[0].keys() %}<th>{{ k }}</th>{% endfor %}</tr></thead>
+  <tbody>
+    {% for row in table %}
+    <tr>{% for v in row.values() %}<td>{{ v }}</td>{% endfor %}</tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% if download_url %}
+<a href="{{ download_url }}" class="btn btn-success">Descargar CSV</a>
+{% endif %}
+{% endif %}

--- a/website/templates/partials/blending_results.html
+++ b/website/templates/partials/blending_results.html
@@ -1,0 +1,7 @@
+{% if metrics %}
+<ul class="list-group mb-3">
+  {% for k, v in metrics.items() %}
+  <li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/website/templates/partials/chat_results.html
+++ b/website/templates/partials/chat_results.html
@@ -1,0 +1,7 @@
+{% if metrics %}
+<ul class="list-group mb-3">
+  {% for k, v in metrics.items() %}
+  <li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/website/templates/partials/comparativo_results.html
+++ b/website/templates/partials/comparativo_results.html
@@ -1,0 +1,15 @@
+{% if table %}
+<table class="table table-bordered mb-3">
+  <thead><tr>{% for k in table[0].keys() %}<th>{{ k }}</th>{% endfor %}</tr></thead>
+  <tbody>
+    {% for row in table %}
+    <tr>{% for v in row.values() %}<td>{{ v }}</td>{% endfor %}</tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% if figure_json %}
+<div id="comparativo-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script>(function(){var el=document.getElementById('comparativo-figure');if(el){var fig=JSON.parse(el.dataset.figure);Plotly.react(el, fig.data, fig.layout);}})();</script>
+{% endif %}

--- a/website/templates/partials/erlang_o_results.html
+++ b/website/templates/partials/erlang_o_results.html
@@ -1,0 +1,7 @@
+{% if metrics %}
+<ul class="list-group mb-3">
+  {% for k, v in metrics.items() %}
+  <li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/website/templates/partials/erlang_visual_results.html
+++ b/website/templates/partials/erlang_visual_results.html
@@ -1,0 +1,14 @@
+{% if metrics %}
+<ul class="list-group mb-3">
+  {% for k, v in metrics.items() %}
+  <li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if figure_json %}
+<div id="erlang-visual-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script>
+  (function(){var el=document.getElementById('erlang-visual-figure');if(el){var fig=JSON.parse(el.dataset.figure);Plotly.react(el, fig.data, fig.layout);}})();
+</script>
+{% endif %}

--- a/website/templates/partials/staffing_results.html
+++ b/website/templates/partials/staffing_results.html
@@ -1,0 +1,20 @@
+{% if table %}
+<table class="table table-bordered mb-3">
+  <thead><tr>{% for k in table[0].keys() %}<th>{{ k }}</th>{% endfor %}</tr></thead>
+  <tbody>
+  {% for row in table %}
+  <tr>{% for v in row.values() %}<td>{{ v }}</td>{% endfor %}</tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% if summary %}
+<ul class="list-group mb-3">
+  {% for k,v in summary.items() %}<li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>{% endfor %}
+</ul>
+{% endif %}
+{% if figure_json %}
+<div id="staffing-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script>(function(){var el=document.getElementById('staffing-figure');if(el){var fig=JSON.parse(el.dataset.figure);Plotly.react(el, fig.data, fig.layout);}})();</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- add routes for Erlang visualisation, chat, blending, outbound, comparative, staffing and batch tools
- port Streamlit logic into reusable services and cores
- build HTMX-enabled templates for new apps with Plotly visualisation and downloads

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sklearn' and other dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_689f92ca3a6c83279daae6f66f631ec4