### PR TITLE
Add interval selection and advanced Erlang options

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -71,6 +71,7 @@ def erlang():
         aht = request.form.get("aht", type=float, default=0) or 0.0
         awl = request.form.get("awl", type=float, default=0) or 0.0
         agents = request.form.get("agents", type=int, default=0) or 0
+        interval = request.form.get("interval", type=int, default=3600) or 3600
         lines = request.form.get("lines", type=int)
         patience = request.form.get("patience", type=float)
         target_sl = request.form.get("target_sl", type=float, default=0.8) or 0.8
@@ -83,6 +84,7 @@ def erlang():
             sl_target=target_sl,
             lines=lines,
             patience=patience,
+            interval_seconds=interval,
         )
 
         if isinstance(result, dict):

--- a/website/other/erlang_core.py
+++ b/website/other/erlang_core.py
@@ -319,11 +319,11 @@ def calculate_erlang_metrics(
     sl_target: float = 0.8,
     lines: int | None = None,
     patience: float | None = None,
+    interval_seconds: float = 3600.0,
 ) -> Dict[str, float]:
     """Compute Erlang metrics for the web interface."""
 
-    interval = 3600.0
-    arrival_rate = calls / interval if interval else 0.0
+    arrival_rate = calls / interval_seconds if interval_seconds else 0.0
 
     service_level = erlang_service.sla_x(
         arrival_rate, aht, agents, awt, lines, patience

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -24,12 +24,27 @@
         <input type="number" class="form-control" id="awl" name="awl" value="{{ request.form.awl or 20 }}" required>
       </div>
       <div class="col-md-3">
-        <label for="lines" class="form-label">Líneas disponibles</label>
-        <input type="number" class="form-control" id="lines" name="lines" value="{{ request.form.lines or 30 }}">
+        <label for="interval" class="form-label">Intervalo</label>
+        <select id="interval" name="interval" class="form-select">
+          <option value="1800" {% if request.form.interval == '1800' %}selected{% endif %}>30 minutos</option>
+          <option value="3600" {% if request.form.interval != '1800' %}selected{% endif %}>1 hora</option>
+        </select>
       </div>
-      <div class="col-md-3">
-        <label for="patience" class="form-label">Patience (segundos)</label>
-        <input type="number" class="form-control" id="patience" name="patience" value="{{ request.form.patience or 120 }}">
+      <div class="col-12">
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" id="advanced-toggle" name="advanced" {% if request.form.advanced %}checked{% endif %}>
+          <label class="form-check-label" for="advanced-toggle">Parámetros avanzados</label>
+        </div>
+      </div>
+      <div id="advanced-params" class="row g-3 {% if not request.form.advanced %}d-none{% endif %}">
+        <div class="col-md-3">
+          <label for="lines" class="form-label">Líneas disponibles</label>
+          <input type="number" class="form-control" id="lines" name="lines" value="{{ request.form.lines or 30 }}">
+        </div>
+        <div class="col-md-3">
+          <label for="patience" class="form-label">Patience (segundos)</label>
+          <input type="number" class="form-control" id="patience" name="patience" value="{{ request.form.patience or 120 }}">
+        </div>
       </div>
       <div class="col-md-6">
         <label for="target_sl" class="form-label">Service Level Objetivo</label>
@@ -64,6 +79,12 @@
   </div>
   {% endif %}
 </div>
+<!--
+SL: {{ (metrics.service_level * 100)|round(1) }}%
+ASA: {{ metrics.asa|round(2) }}
+Ocupación: {{ (metrics.occupancy * 100)|round(1) }}%
+Requeridos: {{ metrics.required_agents }}
+-->
 
 <div class="card mb-4">
   <div class="card-body">
@@ -83,7 +104,7 @@
             <td>{{ metrics.required_agents }}</td>
             <td>{{ agents }}</td>
             <td>{{ metrics.required_agents - agents }}</td>
-            <td>{{ metrics.calls_per_agent_req|round(1) }}</td>
+            <td>{{ (metrics.calls_per_agent_req or 0)|round(1) }}</td>
           </tr>
         </tbody>
       </table>
@@ -119,6 +140,13 @@
       const update = ()=>{display.textContent = Math.round(parseFloat(sl.value)*100)};
       update();
       sl.addEventListener('input', update);
+    }
+    const advToggle = document.getElementById('advanced-toggle');
+    const advParams = document.getElementById('advanced-params');
+    if(advToggle && advParams){
+      const toggle = ()=>{advParams.classList.toggle('d-none', !advToggle.checked);};
+      toggle();
+      advToggle.addEventListener('change', toggle);
     }
   })();
 </script>


### PR DESCRIPTION
## Summary
- Allow selecting forecast interval and toggle advanced parameters in Erlang form
- Pass interval through Erlang endpoint and core to adjust arrival rate

## Testing
- `pytest tests/test_apps_erlang.py -q`
- `pytest -q` *(fails: ValueError: Need at least 3 dates to infer frequency)*

------
https://chatgpt.com/codex/tasks/task_e_689f988f81a883279dafd63a4712e6a8