### PR TITLE
feat: add simulation controls for Erlang visual

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -226,7 +226,9 @@ def erlang_visual_view():
     """Enhanced Erlang view with agent visualisation."""
 
     metrics: Dict[str, Any] = {}
-    figure_json = None
+    matrix = None
+    queue = None
+    asa_bar = None
 
     if request.method == "POST":
         forecast = request.form.get("forecast", type=float, default=0.0) or 0.0
@@ -237,6 +239,14 @@ def erlang_visual_view():
         interval_seconds = 1800 if interval == "1800" else 3600
         sl_target = request.form.get("sl_target", type=float, default=0.8)
 
+        action = request.form.get("action")
+        if action == "increase_demand":
+            forecast *= 1.1
+        elif action == "add_agents":
+            agents += 5
+        elif action == "reduce_aht":
+            aht *= 0.9
+
         arrival_rate = forecast / interval_seconds
         sl = erlang_service.sla_x(arrival_rate, aht, agents, awt)
         asa = erlang_service.waiting_time_erlang_c(arrival_rate, aht, agents)
@@ -245,10 +255,12 @@ def erlang_visual_view():
         hourly_forecast = forecast * 3600 / interval_seconds if interval_seconds else 0
         cpa = hourly_forecast / agents if agents else 0
 
-        fig = erlang_visual.create_agent_visualization(
+        matrix_data = erlang_visual.generate_agent_matrix(
             forecast, aht, agents, awt, interval_seconds, int(required)
         )
-        figure_json = fig.to_json()
+        matrix = matrix_data["rows"]
+        queue = erlang_visual.generate_queue(matrix_data["sl"], forecast)
+        asa_bar = erlang_visual.generate_asa_bar(matrix_data["asa"], awt)
 
         metrics = {
             "service_level": f"{sl:.1%}",
@@ -262,11 +274,17 @@ def erlang_visual_view():
             return render_template(
                 "partials/erlang_visual_results.html",
                 metrics=metrics,
-                figure_json=figure_json,
+                matrix=matrix,
+                queue=queue,
+                asa_bar=asa_bar,
             )
 
     return render_template(
-        "apps/erlang_visual.html", metrics=metrics, figure_json=figure_json
+        "apps/erlang_visual.html",
+        metrics=metrics,
+        matrix=matrix,
+        queue=queue,
+        asa_bar=asa_bar,
     )
 
 

--- a/website/other/erlang_visual.py
+++ b/website/other/erlang_visual.py
@@ -26,6 +26,86 @@ PLACEHOLDER_ICON = "❔"
 PLACEHOLDER_COLOR = "#B0BEC5"
 
 
+def generate_agent_matrix(
+    forecast: float,
+    aht: float,
+    agents: int,
+    awt: float,
+    interval_seconds: int = 3600,
+    required_agents: Optional[int] | None = None,
+):
+    """Build matrix of agent states along with metrics.
+
+    Returns a dictionary with ``rows`` containing icons and colors for each
+    agent cell as well as calculated ``sl``, ``asa`` and ``occupancy``.
+    """
+
+    arrival_rate = forecast / interval_seconds if interval_seconds else 0
+    sl = service_level_erlang_c(arrival_rate, aht, agents, awt)
+    asa = waiting_time_erlang_c(arrival_rate, aht, agents)
+    occupancy = occupancy_erlang_c(arrival_rate, aht, agents)
+
+    agents_per_row = 10
+    display_agents = max(agents, required_agents or agents)
+    busy_agents = int(agents * occupancy)
+    available_agents = agents - busy_agents
+    placeholder_agents = (
+        max(0, (required_agents or agents) - agents)
+        if required_agents is not None
+        else 0
+    )
+
+    states = (
+        ["busy"] * busy_agents
+        + ["available"] * available_agents
+        + ["missing"] * placeholder_agents
+    )
+
+    rows = []
+    avail_index = 0
+    for i in range(0, len(states), agents_per_row):
+        row = []
+        for state in states[i : i + agents_per_row]:
+            if state == "busy":
+                row.append({"icon": BUSY_ICON, "color": BUSY_COLOR})
+            elif state == "available":
+                row.append(
+                    {
+                        "icon": AVAILABLE_ICONS[avail_index % len(AVAILABLE_ICONS)],
+                        "color": AVAILABLE_COLOR,
+                    }
+                )
+                avail_index += 1
+            else:
+                row.append({"icon": PLACEHOLDER_ICON, "color": PLACEHOLDER_COLOR})
+        rows.append(row)
+
+    return {"rows": rows, "sl": sl, "asa": asa, "occupancy": occupancy}
+
+
+def generate_queue(sl: float, forecast: float):
+    """Return queue icons and colour based on service level."""
+    queue_length = max(0, int((1 - sl) * forecast))
+    color = (
+        QUEUE_SHORT_COLOR
+        if queue_length < 3
+        else QUEUE_MED_COLOR
+        if queue_length < 6
+        else QUEUE_LONG_COLOR
+    )
+    return {"icons": [QUEUE_ICON] * queue_length, "color": color}
+
+
+def generate_asa_bar(asa: float, awt: float):
+    """Return ASA progress information."""
+    ratio = asa / awt if awt else 0
+    ratio = max(0.0, min(1.0, ratio))
+    color = (
+        QUEUE_SHORT_COLOR if ratio < 0.5 else QUEUE_MED_COLOR if ratio < 1 else QUEUE_LONG_COLOR
+    )
+    return {"percent": ratio * 100, "value": asa, "target": awt, "color": color}
+
+
 def create_agent_visualization(
     forecast: float,
     aht: float,
@@ -140,6 +220,9 @@ def create_agent_visualization(
 
 
 __all__ = [
+    "generate_agent_matrix",
+    "generate_queue",
+    "generate_asa_bar",
     "create_agent_visualization",
     "BUSY_COLOR",
     "AVAILABLE_COLOR",

--- a/website/templates/apps/erlang_visual.html
+++ b/website/templates/apps/erlang_visual.html
@@ -3,7 +3,7 @@
 <h2 class="fw-bold mb-4">Erlang Visual</h2>
 <div class="card mb-4">
   <div class="card-body">
-    <form method="post" hx-post="{{ url_for('apps.erlang_visual_view') }}" hx-target="#erlang-visual-results" hx-swap="innerHTML" class="row g-3">
+    <form id="erlang-visual-form" method="post" hx-post="{{ url_for('apps.erlang_visual_view') }}" hx-target="#erlang-visual-results" hx-swap="innerHTML" class="row g-3">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="col-md-4">
         <label class="form-label">Forecast</label>
@@ -37,6 +37,30 @@
       </div>
     </form>
   </div>
+</div>
+
+<div class="btn-group mb-4" role="group">
+  <button type="button" class="btn btn-secondary"
+          hx-post="{{ url_for('apps.erlang_visual_view') }}"
+          hx-include="#erlang-visual-form"
+          hx-vals='{"action":"increase_demand"}'
+          hx-target="#erlang-visual-results" hx-swap="innerHTML">
+    Aumentar demanda
+  </button>
+  <button type="button" class="btn btn-secondary"
+          hx-post="{{ url_for('apps.erlang_visual_view') }}"
+          hx-include="#erlang-visual-form"
+          hx-vals='{"action":"add_agents"}'
+          hx-target="#erlang-visual-results" hx-swap="innerHTML">
+    Agregar 5 agentes
+  </button>
+  <button type="button" class="btn btn-secondary"
+          hx-post="{{ url_for('apps.erlang_visual_view') }}"
+          hx-include="#erlang-visual-form"
+          hx-vals='{"action":"reduce_aht"}'
+          hx-target="#erlang-visual-results" hx-swap="innerHTML">
+    Reducir AHT
+  </button>
 </div>
 <div id="erlang-visual-results">
   {% include 'partials/erlang_visual_results.html' %}

--- a/website/templates/partials/erlang_visual_asa.html
+++ b/website/templates/partials/erlang_visual_asa.html
@@ -1,0 +1,7 @@
+{% if asa_bar %}
+<div class="progress mb-3" style="height:20px;">
+  <div class="progress-bar" role="progressbar" style="width: {{ asa_bar.percent }}%; background-color: {{ asa_bar.color }};">
+    ASA {{ asa_bar.value|round(1) }}s / {{ asa_bar.target }}s
+  </div>
+</div>
+{% endif %}

--- a/website/templates/partials/erlang_visual_matrix.html
+++ b/website/templates/partials/erlang_visual_matrix.html
@@ -1,0 +1,18 @@
+{% if matrix %}
+<div class="mb-3">
+  {% for row in matrix %}
+  <div>
+    {% for cell in row %}
+    <span style="font-size:20px;color:{{ cell.color }}">{{ cell.icon }}</span>
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+{% if queue and queue.icons %}
+<div class="mb-3">
+  {% for icon in queue.icons %}
+  <span style="font-size:16px;color:{{ queue.color }}">{{ icon }}</span>
+  {% endfor %}
+</div>
+{% endif %}

--- a/website/templates/partials/erlang_visual_results.html
+++ b/website/templates/partials/erlang_visual_results.html
@@ -5,10 +5,6 @@
   {% endfor %}
 </ul>
 {% endif %}
-{% if figure_json %}
-<div id="erlang-visual-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
-<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-<script>
-  (function(){var el=document.getElementById('erlang-visual-figure');if(el){var fig=JSON.parse(el.dataset.figure);Plotly.react(el, fig.data, fig.layout);}})();
-</script>
-{% endif %}
+
+{% include 'partials/erlang_visual_matrix.html' %}
+{% include 'partials/erlang_visual_asa.html' %}


### PR DESCRIPTION
## Summary
- add HTMX buttons to simulate demand, staffing and AHT changes
- compute agent matrix, queue and ASA bar without plotly
- support HTMX partial responses for Erlang visual

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_wtf')*


------
https://chatgpt.com/codex/tasks/task_e_689f9890687c8327bb5af9b5b4ed2e43