### PR TITLE
Add dynamic chat concurrency inputs and abandonment metrics

### DIFF
--- a/website/templates/apps/chat.html
+++ b/website/templates/apps/chat.html
@@ -10,9 +10,14 @@
         <input type="number" step="any" name="forecast" class="form-control" required>
       </div>
       <div class="col-md-4">
-        <label class="form-label">AHTs (coma separados)</label>
-        <input type="text" name="ahts" class="form-control" placeholder="120,150">
+        <label class="form-label">Máximo chats simultáneos</label>
+        <div class="input-group">
+          <button class="btn btn-outline-secondary" type="button" id="chat-dec">-</button>
+          <input type="number" name="max_chats" id="max-chats" class="form-control" value="1" min="1">
+          <button class="btn btn-outline-secondary" type="button" id="chat-inc">+</button>
+        </div>
       </div>
+      <div id="aht-container" class="row g-3"></div>
       <div class="col-md-4">
         <label class="form-label">Agentes</label>
         <input type="number" name="agents" class="form-control" required>
@@ -33,6 +38,21 @@
         <input type="number" step="any" name="sl_target" class="form-control" value="0.8">
       </div>
       <div class="col-12">
+        <a class="btn btn-link" data-bs-toggle="collapse" href="#chat-advanced" role="button">Parámetros avanzados</a>
+        <div class="collapse" id="chat-advanced">
+          <div class="row g-3 mt-0">
+            <div class="col-md-4">
+              <label class="form-label">Líneas disponibles</label>
+              <input type="number" step="any" name="lines" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Patience (seg)</label>
+              <input type="number" step="any" name="patience" class="form-control">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-12">
         <button class="btn btn-primary" type="submit">Calcular</button>
       </div>
     </form>
@@ -41,4 +61,28 @@
 <div id="chat-results">
   {% include 'partials/chat_results.html' %}
 </div>
+<script>
+  (function(){
+    const inc = document.getElementById('chat-inc');
+    const dec = document.getElementById('chat-dec');
+    const max = document.getElementById('max-chats');
+    const container = document.getElementById('aht-container');
+
+    function renderFields(){
+      const n = parseInt(max.value || 0);
+      container.innerHTML = '';
+      for(let i=1; i<=n; i++){
+        const div = document.createElement('div');
+        div.className = 'col-md-4';
+        div.innerHTML = `<label class="form-label">AHT simultaneidad ${i}</label>` +
+                        `<input type="number" step="any" name="ahts" class="form-control">`;
+        container.appendChild(div);
+      }
+    }
+
+    inc.addEventListener('click', ()=>{max.value = parseInt(max.value||0) + 1; renderFields();});
+    dec.addEventListener('click', ()=>{max.value = Math.max(1, parseInt(max.value||0) - 1); renderFields();});
+    renderFields();
+  })();
+</script>
 {% endblock %}

--- a/website/templates/partials/chat_results.html
+++ b/website/templates/partials/chat_results.html
@@ -1,7 +1,10 @@
 {% if metrics %}
 <ul class="list-group mb-3">
-  {% for k, v in metrics.items() %}
-  <li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>
-  {% endfor %}
+  <li class="list-group-item d-flex justify-content-between"><span>Service Level</span><span>{{ metrics.service_level }}</span></li>
+  <li class="list-group-item d-flex justify-content-between"><span>ASA</span><span>{{ metrics.asa }}</span></li>
+  {% if metrics.abandonment is defined %}
+  <li class="list-group-item d-flex justify-content-between"><span>Abandono</span><span>{{ metrics.abandonment }}</span></li>
+  {% endif %}
+  <li class="list-group-item d-flex justify-content-between"><span>Agentes Requeridos</span><span>{{ metrics.required_agents }}</span></li>
 </ul>
 {% endif %}


### PR DESCRIPTION
## Summary
- add controls to configure maximum simultaneous chats and dynamic AHT inputs
- expose advanced chat options for lines and patience
- compute chat abandonment when patience is provided and display result

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_wtf')*


------
https://chatgpt.com/codex/tasks/task_e_689f9891c9688327b953fe18593afcba