### PR TITLE
Add advanced parameters and sensitivity plot to blending app

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -169,6 +169,7 @@ def timeseries():
     """
 
     metrics: Dict[str, Any] = {}
+    figure_json = None
     recommendation = ""
     weekly_table = []
     heatmap_json = None
@@ -275,6 +276,7 @@ def chat():
     """Chat multi-channel calculator."""
 
     metrics: Dict[str, Any] = {}
+    figure_json = None
 
     if request.method == "POST":
         forecast = request.form.get("forecast", type=float, default=0.0) or 0.0
@@ -316,6 +318,7 @@ def blending():
     """Blending calculator."""
 
     metrics: Dict[str, Any] = {}
+    figure_json = None
 
     if request.method == "POST":
         forecast = request.form.get("forecast", type=float, default=0.0) or 0.0
@@ -326,23 +329,90 @@ def blending():
         interval = request.form.get("interval", default="3600")
         interval_seconds = 1800 if interval == "1800" else 3600
         sl_target = request.form.get("sl_target", type=float, default=0.8)
+        lines = request.form.get("lines", type=int)
+        patience = request.form.get("patience", type=float)
 
         arrival_rate = forecast / interval_seconds
         sl = erlang_service.bl_sla(
-            arrival_rate, aht, agents, awt, None, None, threshold
+            arrival_rate, aht, agents, awt, lines, patience, threshold
+        )
+        outbound = (
+            erlang_service.bl_outbound_capacity(
+                arrival_rate, aht, agents, lines, patience, threshold, aht
+            )
+            * 3600
         )
         optimal = erlang_service.bl_optimal_threshold(
-            arrival_rate, aht, agents, awt, None, None, sl_target
+            arrival_rate, aht, agents, awt, lines, patience, sl_target
         )
         metrics = {
             "service_level": f"{sl:.1%}",
+            "outbound_capacity": f"{outbound:.1f} llamadas/h",
             "optimal_threshold": f"{optimal:.1f}",
         }
 
-        if request.headers.get("HX-Request"):
-            return render_template("partials/blending_results.html", metrics=metrics)
+        threshold_range = range(0, int(agents * 0.4))
+        sl_data = []
+        outbound_data = []
+        for t in threshold_range:
+            sl_val = erlang_service.bl_sla(
+                arrival_rate, aht, agents, awt, lines, patience, t
+            )
+            out_val = (
+                erlang_service.bl_outbound_capacity(
+                    arrival_rate, aht, agents, lines, patience, t, aht
+                )
+                * 3600
+            )
+            sl_data.append(sl_val)
+            outbound_data.append(out_val)
 
-    return render_template("apps/blending.html", metrics=metrics)
+        fig = go.Figure()
+        fig.add_trace(
+            go.Scatter(
+                x=list(threshold_range),
+                y=sl_data,
+                mode="lines+markers",
+                name="Service Level Inbound",
+                yaxis="y",
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=list(threshold_range),
+                y=outbound_data,
+                mode="lines+markers",
+                name="Capacidad Outbound",
+                yaxis="y2",
+            )
+        )
+        fig.update_layout(
+            title="Service Level vs Capacidad Outbound por Threshold",
+            xaxis_title="Threshold (Agentes Reservados)",
+            yaxis=dict(title="Service Level Inbound", side="left", range=[0, 1]),
+            yaxis2=dict(
+                title="Capacidad Outbound (llamadas/hora)",
+                side="right",
+                overlaying="y",
+            ),
+            hovermode="x unified",
+        )
+        fig.add_vline(
+            x=threshold, line_dash="dash", line_color="red", annotation_text="Actual"
+        )
+        fig.add_vline(
+            x=optimal, line_dash="dash", line_color="orange", annotation_text="Óptimo"
+        )
+        figure_json = fig.to_json()
+
+        if request.headers.get("HX-Request"):
+            return render_template(
+                "partials/blending_results.html", metrics=metrics, figure_json=figure_json
+            )
+
+    return render_template(
+        "apps/blending.html", metrics=metrics, figure_json=figure_json
+    )
 
 
 @apps_bp.route("/erlang_o", methods=["GET", "POST"])

--- a/website/templates/apps/blending.html
+++ b/website/templates/apps/blending.html
@@ -37,6 +37,21 @@
         <input type="number" step="any" name="sl_target" class="form-control" value="0.8">
       </div>
       <div class="col-12">
+        <details>
+          <summary>Avanzado</summary>
+          <div class="row g-3 mt-1">
+            <div class="col-md-4">
+              <label class="form-label">Líneas</label>
+              <input type="number" name="lines" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Patience (seg)</label>
+              <input type="number" step="any" name="patience" class="form-control">
+            </div>
+          </div>
+        </details>
+      </div>
+      <div class="col-12">
         <button class="btn btn-primary" type="submit">Calcular</button>
       </div>
     </form>

--- a/website/templates/partials/blending_results.html
+++ b/website/templates/partials/blending_results.html
@@ -1,7 +1,17 @@
 {% if metrics %}
 <ul class="list-group mb-3">
-  {% for k, v in metrics.items() %}
-  <li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>
-  {% endfor %}
+  <li class="list-group-item d-flex justify-content-between"><span>SL inbound</span><span>{{ metrics.service_level }}</span></li>
+  <li class="list-group-item d-flex justify-content-between"><span>Capacidad outbound</span><span>{{ metrics.outbound_capacity }}</span></li>
+  <li class="list-group-item d-flex justify-content-between"><span>Threshold óptimo</span><span>{{ metrics.optimal_threshold }}</span></li>
 </ul>
+{% endif %}
+{% if figure_json %}
+<div id="blending-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script>
+  (function(){
+    var el=document.getElementById('blending-figure');
+    if(el){var fig=JSON.parse(el.dataset.figure);Plotly.react(el, fig.data, fig.layout);}
+  })();
+</script>
 {% endif %}


### PR DESCRIPTION
## Summary
- add advanced lines and patience fields to blending form
- compute outbound capacity and optimal threshold with new parameters
- render Plotly sensitivity analysis for threshold

## Testing
- `pip install -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*
- `pytest` *(fails: cannot import name 'load_demand_from_excel')*

------
https://chatgpt.com/codex/tasks/task_e_689f9892eef88327930883e646c43734