### PR TITLE
feat: add staffing pattern analysis

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -408,6 +408,8 @@ def staffing():
     table = []
     figure_json = None
     summary = {}
+    analysis = []
+    recommendations = []
 
     if request.method == "POST":
         forecasts_raw = request.form.get("forecasts", "")
@@ -419,12 +421,23 @@ def staffing():
         interval = request.form.get("interval", default="3600")
         interval_seconds = 1800 if interval == "1800" else 3600
         sl_target = request.form.get("sl_target", type=float, default=0.8)
+        start_time = request.form.get("start_time")
+        end_time = request.form.get("end_time")
+        pattern = request.form.get("pattern", "manual")
 
         result = staffing_core.staffing_optimizer(
-            forecasts, aht, interval_seconds, sl_target
+            forecasts,
+            aht,
+            interval_seconds,
+            sl_target,
+            start_time=start_time,
+            end_time=end_time,
+            pattern=pattern,
         )
         table = result.get("table", [])
         summary = result.get("summary", {})
+        analysis = result.get("analysis", [])
+        recommendations = result.get("recommendations", [])
         fig = result.get("figure")
         if isinstance(fig, dict):
             figure_json = json.dumps(fig)
@@ -436,11 +449,18 @@ def staffing():
                 "partials/staffing_results.html",
                 table=table,
                 summary=summary,
+                analysis=analysis,
+                recommendations=recommendations,
                 figure_json=figure_json,
             )
 
     return render_template(
-        "apps/staffing.html", table=table, summary=summary, figure_json=figure_json
+        "apps/staffing.html",
+        table=table,
+        summary=summary,
+        analysis=analysis,
+        recommendations=recommendations,
+        figure_json=figure_json,
     )
 
 

--- a/website/other/staffing_core.py
+++ b/website/other/staffing_core.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 
 from typing import Dict, Any, Iterable, List
 
+
+def _parse_hour(value: str | None) -> int:
+    """Return hour integer from HH:MM strings."""
+    if not value:
+        return 0
+    try:
+        return int(value.split(":", 1)[0])
+    except (ValueError, AttributeError):
+        return 0
+
 import plotly.graph_objects as go
 
 from ..services.erlang import service_level_erlang_c, waiting_time_erlang_c, agents_for_sla
@@ -14,10 +24,29 @@ def staffing_optimizer(
     interval_seconds: int,
     sl_target: float,
     awt: float = 20.0,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    pattern: str = "manual",
 ) -> Dict[str, Any]:
     """Return per-hour staffing recommendations."""
-    hours = list(range(len(list(forecasts))))
-    forecasts = list(forecasts)
+    predefined_patterns = {
+        "call_center": (9, [100, 120, 140, 160, 180, 160, 140, 120, 100]),
+        "ecommerce": (8, [80, 100, 130, 160, 180, 170, 160, 150, 140, 120, 100, 80]),
+        "soporte": (0, [60] * 24),
+    }
+
+    if pattern != "manual" and pattern in predefined_patterns:
+        start_hour, pattern_forecasts = predefined_patterns[pattern]
+        forecasts = pattern_forecasts
+    else:
+        start_hour = _parse_hour(start_time)
+        forecasts = list(forecasts)
+        if end_time:
+            end_hour = _parse_hour(end_time)
+            length = end_hour - start_hour
+            if length > len(forecasts):
+                forecasts.extend([0] * (length - len(forecasts)))
+    hours = [start_hour + i for i in range(len(forecasts))]
     table: List[Dict[str, Any]] = []
     total_agent_hours = 0
     agent_series: List[float] = []
@@ -40,22 +69,49 @@ def staffing_optimizer(
         agent_series.append(agents_needed)
 
     fig = go.Figure()
-    fig.add_trace(go.Scatter(x=hours, y=forecasts, name="Forecast"))
-    fig.add_trace(go.Scatter(x=hours, y=agent_series, name="Agentes"))
+    fig.add_trace(go.Scatter(x=hours, y=forecasts, name="Forecast", yaxis="y"))
+    fig.add_trace(
+        go.Scatter(x=hours, y=agent_series, name="Agentes Requeridos", yaxis="y2")
+    )
     fig.update_layout(
-        title="Forecast vs Agentes Necesarios",
+        title="Forecast vs Agentes Requeridos",
         xaxis_title="Hora",
-        yaxis_title="Cantidad",
+        yaxis=dict(title="Forecast"),
+        yaxis2=dict(title="Agentes", overlaying="y", side="right"),
     )
 
+    peak_agents = max(agent_series) if agent_series else 0
+    valley_agents = min(agent_series) if agent_series else 0
+    avg_agents = total_agent_hours / len(agent_series) if agent_series else 0
     summary = {
-        "max_agents": max(agent_series) if agent_series else 0,
-        "min_agents": min(agent_series) if agent_series else 0,
-        "avg_agents": total_agent_hours / len(agent_series) if agent_series else 0,
-        "total_agent_hours": total_agent_hours,
+        "Pico": peak_agents,
+        "Valle": valley_agents,
+        "Promedio": round(avg_agents, 2),
+        "Total agente-horas": total_agent_hours,
     }
+    analysis = [
+        {"Métrica": "Pico", "Valor": peak_agents},
+        {"Métrica": "Valle", "Valor": valley_agents},
+        {"Métrica": "Promedio", "Valor": round(avg_agents, 2)},
+        {"Métrica": "Total agente-horas", "Valor": total_agent_hours},
+    ]
+    recommendations: List[str] = []
+    if peak_agents > avg_agents * 1.2:
+        recommendations.append(
+            "Considera turnos escalonados para cubrir horas pico."
+        )
+    if valley_agents < avg_agents * 0.8:
+        recommendations.append("Reducir personal en horas valle.")
+    if not recommendations:
+        recommendations.append("Distribución de agentes balanceada.")
 
-    return {"table": table, "figure": fig.to_dict(), "summary": summary}
+    return {
+        "table": table,
+        "figure": fig.to_dict(),
+        "summary": summary,
+        "analysis": analysis,
+        "recommendations": recommendations,
+    }
 
 
 __all__ = ["staffing_optimizer"]

--- a/website/templates/apps/staffing.html
+++ b/website/templates/apps/staffing.html
@@ -8,6 +8,16 @@
       <div class="col-md-6"><label class="form-label">Forecasts por hora (coma separados)</label><input type="text" name="forecasts" class="form-control" placeholder="100,120,140"></div>
       <div class="col-md-3"><label class="form-label">AHT (seg)</label><input type="number" step="any" name="aht" class="form-control" required></div>
       <div class="col-md-3"><label class="form-label">Intervalo</label><select name="interval" class="form-select"><option value="1800">30 minutos</option><option value="3600" selected>1 hora</option></select></div>
+      <div class="col-md-3"><label class="form-label">Hora Inicio</label><input type="time" name="start_time" class="form-control" value="09:00"></div>
+      <div class="col-md-3"><label class="form-label">Hora Fin</label><input type="time" name="end_time" class="form-control" value="18:00"></div>
+      <div class="col-md-3"><label class="form-label">Patrón</label>
+        <select name="pattern" class="form-select">
+          <option value="manual" selected>Manual</option>
+          <option value="call_center">Call Center</option>
+          <option value="ecommerce">E-commerce</option>
+          <option value="soporte">Soporte</option>
+        </select>
+      </div>
       <div class="col-md-3"><label class="form-label">SL Objetivo</label><input type="number" step="any" name="sl_target" class="form-control" value="0.8"></div>
       <div class="col-12"><button class="btn btn-primary" type="submit">Calcular</button></div>
     </form>

--- a/website/templates/partials/staffing_results.html
+++ b/website/templates/partials/staffing_results.html
@@ -13,6 +13,21 @@
   {% for k,v in summary.items() %}<li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>{% endfor %}
 </ul>
 {% endif %}
+{% if analysis %}
+<h4>Análisis de Turnos</h4>
+<table class="table table-sm mb-3">
+  <tbody>
+  {% for row in analysis %}
+  <tr><td>{{ row['Métrica'] }}</td><td>{{ row['Valor'] }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% if recommendations %}
+<div class="alert alert-info"><ul class="mb-0">
+  {% for rec in recommendations %}<li>{{ rec }}</li>{% endfor %}
+</ul></div>
+{% endif %}
 {% if figure_json %}
 <div id="staffing-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>


### PR DESCRIPTION
## Summary
- add start/end time fields and pattern selector to staffing form
- generate predefined staffing patterns with dual-axis Plotly chart and shift metrics
- include shift analysis and recommendations in results

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_689f98949bec83278db4d537f180cf2d