### PR TITLE
Consolidate Erlang app routes under common prefix

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -220,13 +220,7 @@ def series():
     return timeseries()
 
 
-@apps_bp.route("/erlang/<path:submodule>", methods=["GET", "POST"])
-def erlang_submodule(submodule: str):
-    """Dispatch any Erlang submodule to the main view."""
-    return erlang()
-
-
-@apps_bp.route("/erlang_visual", methods=["GET", "POST"])
+@apps_bp.route("/erlang/visual", methods=["GET", "POST"])
 def erlang_visual_view():
     """Enhanced Erlang view with agent visualisation."""
 
@@ -293,7 +287,7 @@ def erlang_visual_view():
     )
 
 
-@apps_bp.route("/chat", methods=["GET", "POST"])
+@apps_bp.route("/erlang/chat", methods=["GET", "POST"])
 def chat():
     """Chat multi-channel calculator."""
 
@@ -343,7 +337,7 @@ def chat():
     return render_template("apps/chat.html", metrics=metrics)
 
 
-@apps_bp.route("/blending", methods=["GET", "POST"])
+@apps_bp.route("/erlang/blending", methods=["GET", "POST"])
 def blending():
     """Blending calculator."""
 
@@ -445,7 +439,7 @@ def blending():
     )
 
 
-@apps_bp.route("/erlang_o", methods=["GET", "POST"])
+@apps_bp.route("/erlang/o", methods=["GET", "POST"])
 def erlang_o_view():
     """Erlang O outbound calculator."""
 

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -2,6 +2,13 @@
 
 {% block app_content %}
 <h2 class="fw-bold mb-4">Erlang</h2>
+<nav class="nav nav-pills mb-4">
+  <a class="nav-link {{ 'active' if request.endpoint=='apps.erlang' else '' }}" href="{{ url_for('apps.erlang') }}">Clásico</a>
+  <a class="nav-link {{ 'active' if request.endpoint=='apps.erlang_visual_view' else '' }}" href="{{ url_for('apps.erlang_visual_view') }}">Visual</a>
+  <a class="nav-link {{ 'active' if request.endpoint=='apps.chat' else '' }}" href="{{ url_for('apps.chat') }}">Chat</a>
+  <a class="nav-link {{ 'active' if request.endpoint=='apps.blending' else '' }}" href="{{ url_for('apps.blending') }}">Blending</a>
+  <a class="nav-link {{ 'active' if request.endpoint=='apps.erlang_o_view' else '' }}" href="{{ url_for('apps.erlang_o_view') }}">Erlang O</a>
+</nav>
 
 <div class="card mb-4">
   <div class="card-body">

--- a/website/templates/apps/layout.html
+++ b/website/templates/apps/layout.html
@@ -5,7 +5,17 @@
   <aside class="col-md-3 col-lg-2 mb-4">
     <div class="list-group">
       <a href="{{ url_for('core.generador') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.generador' else '' }}">Generador</a>
-      <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint.startswith('apps.erlang') else '' }}">Erlang</a>
+      {% set erlang_endpoints = ['apps.erlang', 'apps.erlang_visual_view', 'apps.chat', 'apps.blending', 'apps.erlang_o_view'] %}
+      <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint in erlang_endpoints else '' }}">Erlang</a>
+      {% if request.endpoint in erlang_endpoints %}
+      <div class="list-group ms-3">
+        <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.erlang' else '' }}">Clásico</a>
+        <a href="{{ url_for('apps.erlang_visual_view') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.erlang_visual_view' else '' }}">Visual</a>
+        <a href="{{ url_for('apps.chat') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.chat' else '' }}">Chat</a>
+        <a href="{{ url_for('apps.blending') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.blending' else '' }}">Blending</a>
+        <a href="{{ url_for('apps.erlang_o_view') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.erlang_o_view' else '' }}">Erlang O</a>
+      </div>
+      {% endif %}
       <a href="{{ url_for('apps.kpis') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.kpis' else '' }}">KPIs</a>
       <a href="{{ url_for('apps.series') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint in ['apps.series', 'apps.timeseries'] else '' }}">Series</a>
       <a href="{{ url_for('apps.predictivo') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.predictivo' else '' }}">Predictivo</a>


### PR DESCRIPTION
## Summary
- Route Erlang submodules under `/apps/erlang/<submodule>` (chat, blending, visual and Erlang O)
- Add sidebar and in-page navigation to switch between Erlang submodules

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_689fb3ca888c83279917edf7742bba48