### PR TITLE
feat: enhance erlang visual metrics

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -260,6 +260,17 @@ def erlang_visual_view():
         hourly_forecast = forecast * 3600 / interval_seconds if interval_seconds else 0
         cpa = hourly_forecast / agents if agents else 0
 
+        busy_agents = int(agents * occ)
+        available_agents = max(0, agents - busy_agents)
+        busy_pct = busy_agents / agents * 100 if agents else 0
+        available_pct = available_agents / agents * 100 if agents else 0
+
+        sl_class = "success" if sl >= 0.8 else "warning" if sl >= 0.7 else "danger"
+        asa_class = "success" if asa <= 30 else "warning" if asa <= 60 else "danger"
+        occ_class = (
+            "success" if 0.7 <= occ <= 0.85 else "warning" if 0.6 <= occ <= 0.9 else "danger"
+        )
+
         matrix_data = erlang_visual.generate_agent_matrix(
             forecast, aht, agents, awt, interval_seconds, int(required)
         )
@@ -268,11 +279,18 @@ def erlang_visual_view():
         asa_bar = erlang_visual.generate_asa_bar(matrix_data["asa"], awt)
 
         metrics = {
-            "service_level": f"{sl:.1%}",
-            "asa": f"{asa:.1f}",
-            "occupancy": f"{occ:.1%}",
+            "service_level": sl,
+            "asa": asa,
+            "occupancy": occ,
             "required_agents": int(required),
-            "calls_per_agent": f"{cpa:.1f}",
+            "calls_per_agent": cpa,
+            "busy_agents": busy_agents,
+            "available_agents": available_agents,
+            "busy_percent": busy_pct,
+            "available_percent": available_pct,
+            "sl_class": sl_class,
+            "asa_class": asa_class,
+            "occ_class": occ_class,
         }
 
         if request.headers.get("HX-Request"):

--- a/website/templates/partials/erlang_visual_results.html
+++ b/website/templates/partials/erlang_visual_results.html
@@ -1,9 +1,26 @@
 {% if metrics %}
-<ul class="list-group mb-3">
-  {% for k, v in metrics.items() %}
-  <li class="list-group-item d-flex justify-content-between"><span>{{ k }}</span><span>{{ v }}</span></li>
-  {% endfor %}
-</ul>
+<div class="metrics-grid mb-3">
+  <div class="metric-card {{ metrics.sl_class }}">
+    <h3>Service Level</h3>
+    <h2>{{ (metrics.service_level * 100)|round(1) }}%</h2>
+  </div>
+  <div class="metric-card {{ metrics.asa_class }}">
+    <h3>ASA</h3>
+    <h2>{{ metrics.asa|round(1) }}s</h2>
+  </div>
+  <div class="metric-card {{ metrics.occ_class }}">
+    <h3>Ocupación</h3>
+    <h2>{{ (metrics.occupancy * 100)|round(1) }}%</h2>
+  </div>
+</div>
+<div class="progress mb-3" style="height:20px;">
+  <div class="progress-bar" role="progressbar" style="width: {{ metrics.busy_percent }}%; background-color: #EF476F;">
+    Ocupados {{ metrics.busy_agents }}
+  </div>
+  <div class="progress-bar" role="progressbar" style="width: {{ metrics.available_percent }}%; background-color: #06D6A0;">
+    Disponibles {{ metrics.available_agents }}
+  </div>
+</div>
 {% endif %}
 
 {% include 'partials/erlang_visual_matrix.html' %}


### PR DESCRIPTION
## Summary
- render Erlang visual results as metric cards with status bars
- compute busy/available agent states and metric classes

## Testing
- `pytest` *(fails: No module named 'flask_wtf')*


------
https://chatgpt.com/codex/tasks/task_e_689fb3d08ccc8327b58c5535e072e75a