### PR TITLE
Nest Erlang tools under /erlang paths

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -542,7 +542,7 @@ def erlang_o_view():
     return render_template("apps/erlang_o.html", metrics=metrics, figure_json=figure_json)
 
 
-@apps_bp.route("/comparativo", methods=["GET", "POST"])
+@apps_bp.route("/erlang/comparativo", methods=["GET", "POST"])
 def comparativo():
     """Run comparative analysis across models."""
 
@@ -579,7 +579,7 @@ def comparativo():
     )
 
 
-@apps_bp.route("/staffing", methods=["GET", "POST"])
+@apps_bp.route("/erlang/staffing", methods=["GET", "POST"])
 def staffing():
     """Staffing optimisation utility."""
 
@@ -642,7 +642,7 @@ def staffing():
     )
 
 
-@apps_bp.route("/batch", methods=["GET", "POST"])
+@apps_bp.route("/erlang/batch", methods=["GET", "POST"])
 def batch():
     """Batch processing of contact centre scenarios."""
 
@@ -702,7 +702,7 @@ def batch():
     )
 
 
-@apps_bp.route("/batch/download/<job_id>.<ext>")
+@apps_bp.route("/erlang/batch/download/<job_id>.<ext>")
 def batch_download(job_id: str, ext: str):
     """Send processed batch results in the requested format."""
     path = os.path.join(temp_dir, f"{job_id}.{ext}")

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -8,6 +8,9 @@
   <a class="nav-link {{ 'active' if request.endpoint=='apps.chat' else '' }}" href="{{ url_for('apps.chat') }}">Chat</a>
   <a class="nav-link {{ 'active' if request.endpoint=='apps.blending' else '' }}" href="{{ url_for('apps.blending') }}">Blending</a>
   <a class="nav-link {{ 'active' if request.endpoint=='apps.erlang_o_view' else '' }}" href="{{ url_for('apps.erlang_o_view') }}">Erlang O</a>
+  <a class="nav-link {{ 'active' if request.endpoint=='apps.comparativo' else '' }}" href="{{ url_for('apps.comparativo') }}">Comparativo</a>
+  <a class="nav-link {{ 'active' if request.endpoint=='apps.staffing' else '' }}" href="{{ url_for('apps.staffing') }}">Staffing</a>
+  <a class="nav-link {{ 'active' if request.endpoint in ['apps.batch', 'apps.batch_download'] else '' }}" href="{{ url_for('apps.batch') }}">Batch</a>
 </nav>
 
 <div class="card mb-4">

--- a/website/templates/apps/layout.html
+++ b/website/templates/apps/layout.html
@@ -5,7 +5,17 @@
   <aside class="col-md-3 col-lg-2 mb-4">
     <div class="list-group">
       <a href="{{ url_for('core.generador') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='core.generador' else '' }}">Generador</a>
-      {% set erlang_endpoints = ['apps.erlang', 'apps.erlang_visual_view', 'apps.chat', 'apps.blending', 'apps.erlang_o_view'] %}
+        {% set erlang_endpoints = [
+          'apps.erlang',
+          'apps.erlang_visual_view',
+          'apps.chat',
+          'apps.blending',
+          'apps.erlang_o_view',
+          'apps.comparativo',
+          'apps.staffing',
+          'apps.batch',
+          'apps.batch_download'
+        ] %}
       <a href="{{ url_for('apps.erlang') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint in erlang_endpoints else '' }}">Erlang</a>
       {% if request.endpoint in erlang_endpoints %}
       <div class="list-group ms-3">
@@ -14,6 +24,9 @@
         <a href="{{ url_for('apps.chat') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.chat' else '' }}">Chat</a>
         <a href="{{ url_for('apps.blending') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.blending' else '' }}">Blending</a>
         <a href="{{ url_for('apps.erlang_o_view') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.erlang_o_view' else '' }}">Erlang O</a>
+        <a href="{{ url_for('apps.comparativo') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.comparativo' else '' }}">Comparativo</a>
+        <a href="{{ url_for('apps.staffing') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.staffing' else '' }}">Staffing</a>
+        <a href="{{ url_for('apps.batch') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint in ['apps.batch', 'apps.batch_download'] else '' }}">Batch</a>
       </div>
       {% endif %}
       <a href="{{ url_for('apps.kpis') }}" class="list-group-item list-group-item-action {{ 'active' if request.endpoint=='apps.kpis' else '' }}">KPIs</a>


### PR DESCRIPTION
## Summary
- Serve comparativo, staffing and batch utilities under `/apps/erlang/*`
- Link comparativo, staffing and batch in Erlang side menu and nav bar

## Testing
- `pytest` *(fails: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Getting requirements to build wheel: finished with status 'error')*


------
https://chatgpt.com/codex/tasks/task_e_689fb8dbcfcc8327b577cd6d8265187a