### PR TITLE
Add waiting state metrics and circular panel to Erlang visual

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -256,14 +256,6 @@ def erlang_visual_view():
 
         busy_agents = int(agents * occ)
         available_agents = max(0, agents - busy_agents)
-        busy_pct = busy_agents / agents * 100 if agents else 0
-        available_pct = available_agents / agents * 100 if agents else 0
-
-        sl_class = "success" if sl >= 0.8 else "warning" if sl >= 0.7 else "danger"
-        asa_class = "success" if asa <= 30 else "warning" if asa <= 60 else "danger"
-        occ_class = (
-            "success" if 0.7 <= occ <= 0.85 else "warning" if 0.6 <= occ <= 0.9 else "danger"
-        )
 
         matrix_data = erlang_visual.generate_agent_matrix(
             forecast, aht, agents, awt, interval_seconds, int(required)
@@ -271,6 +263,18 @@ def erlang_visual_view():
         matrix = matrix_data["rows"]
         queue = erlang_visual.generate_queue(matrix_data["sl"], forecast)
         asa_bar = erlang_visual.generate_asa_bar(matrix_data["asa"], awt)
+
+        waiting_calls = len(queue["icons"]) if queue else 0
+        total_units = agents + waiting_calls
+        busy_pct = busy_agents / total_units * 100 if total_units else 0
+        available_pct = available_agents / total_units * 100 if total_units else 0
+        waiting_pct = waiting_calls / total_units * 100 if total_units else 0
+
+        sl_class = "success" if sl >= 0.8 else "warning" if sl >= 0.7 else "danger"
+        asa_class = "success" if asa <= 30 else "warning" if asa <= 60 else "danger"
+        occ_class = (
+            "success" if 0.7 <= occ <= 0.85 else "warning" if 0.6 <= occ <= 0.9 else "danger"
+        )
 
         metrics = {
             "service_level": sl,
@@ -280,8 +284,10 @@ def erlang_visual_view():
             "calls_per_agent": cpa,
             "busy_agents": busy_agents,
             "available_agents": available_agents,
+            "waiting_calls": waiting_calls,
             "busy_percent": busy_pct,
             "available_percent": available_pct,
+            "waiting_percent": waiting_pct,
             "sl_class": sl_class,
             "asa_class": asa_class,
             "occ_class": occ_class,

--- a/website/static/css/apps.css
+++ b/website/static/css/apps.css
@@ -33,3 +33,33 @@ main.container-xxl {
   border: 1px solid #dc3545;
   background: rgba(220, 53, 69, 0.15);
 }
+
+/* Circular metrics panel */
+.metrics-circle {
+  position: relative;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+}
+
+.metrics-circle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 60%;
+  height: 60%;
+  background: #fff;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.metrics-circle-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  font-size: 0.8rem;
+  line-height: 1.2;
+}

--- a/website/templates/partials/erlang_visual_results.html
+++ b/website/templates/partials/erlang_visual_results.html
@@ -1,4 +1,5 @@
 {% if metrics %}
+{% set wait_color = queue.color if queue else '#FFD166' %}
 <div class="metrics-grid mb-3">
   <div class="metric-card {{ metrics.sl_class }}">
     <h3>Service Level</h3>
@@ -13,9 +14,21 @@
     <h2>{{ (metrics.occupancy * 100)|round(1) }}%</h2>
   </div>
 </div>
+<div class="d-flex justify-content-center mb-3">
+  <div class="metrics-circle" style="background: conic-gradient(#EF476F {{ metrics.busy_percent }}%, {{ wait_color }} {{ metrics.busy_percent }}% {{ metrics.busy_percent + metrics.waiting_percent }}%, #06D6A0 {{ metrics.busy_percent + metrics.waiting_percent }}%);">
+    <div class="metrics-circle-label">
+      <div>Ocupados {{ metrics.busy_agents }}</div>
+      <div>Esperando {{ metrics.waiting_calls }}</div>
+      <div>Disponibles {{ metrics.available_agents }}</div>
+    </div>
+  </div>
+</div>
 <div class="progress mb-3" style="height:20px;">
   <div class="progress-bar" role="progressbar" style="width: {{ metrics.busy_percent }}%; background-color: #EF476F;">
     Ocupados {{ metrics.busy_agents }}
+  </div>
+  <div class="progress-bar" role="progressbar" style="width: {{ metrics.waiting_percent }}%; background-color: {{ wait_color }};">
+    Esperando {{ metrics.waiting_calls }}
   </div>
   <div class="progress-bar" role="progressbar" style="width: {{ metrics.available_percent }}%; background-color: #06D6A0;">
     Disponibles {{ metrics.available_agents }}


### PR DESCRIPTION
## Summary
- extend Erlang visual view to calculate waiting callers and percentages
- add circular agent metrics panel and waiting segment in results template
- style new metrics circle with reusable colors

## Testing
- `pytest tests/test_apps_erlang.py -q` *(fails: assert 404 == 200)*


------
https://chatgpt.com/codex/tasks/task_e_689fb8e130588327b8530ace41780332