### PR TITLE
Validate Erlang form inputs and handle calculation errors

### DIFF
--- a/website/other/modelo_predictivo_core.py
+++ b/website/other/modelo_predictivo_core.py
@@ -43,7 +43,10 @@ def detectar_frecuencia(series: pd.Series) -> str:
     Falls back to simple heuristics when ``pd.infer_freq`` fails.
     """
 
-    freq = pd.infer_freq(series.index)
+    try:
+        freq = pd.infer_freq(series.index)
+    except Exception:
+        freq = None
     if freq:
         return freq
     dias = series.index.to_series().diff().dt.days.mean()


### PR DESCRIPTION
## Summary
- add validation for Erlang calculator inputs and return form values on error
- wrap Erlang metric calculations with logging and user-facing error flashes
- initialize predictive download links and guard frequency detection for short datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc439f6488327b3650f046f89f8e7