### PR TITLE
Refactor download URLs in batch and predictivo routes

### DIFF
--- a/website/blueprints/apps.py
+++ b/website/blueprints/apps.py
@@ -107,12 +107,16 @@ def erlang():
 
 @apps_bp.route("/predictivo", methods=["GET", "POST"])
 def predictivo():
-    """Execute the predictive model workflow."""
+    """Execute the predictive model workflow.
+
+    When a file is processed successfully a temporary CSV is generated in the
+    system's temp directory.  ``download_url`` holds the link for the user to
+    retrieve that file.
+    """
 
     metrics = {}
     table = []
-    download_url_csv = None
-    download_url_xlsx = None
+    download_url = None
 
     if request.method == "POST":
         file = request.files.get("file")
@@ -650,11 +654,14 @@ def staffing():
 
 @apps_bp.route("/erlang/batch", methods=["GET", "POST"])
 def batch():
-    """Batch processing of contact centre scenarios."""
+    """Batch processing of contact centre scenarios.
+
+    ``download_url`` is a mapping of file extensions to their respective
+    temporary download links generated after processing.
+    """
 
     table = []
-    download_url_csv = None
-    download_url_xlsx = None
+    download_url: Dict[str, str] = {}
 
     if request.method == "POST":
         file = request.files.get("file")
@@ -689,22 +696,20 @@ def batch():
                 f.write(csv_bytes)
             with open(xlsx_path, "wb") as f:
                 f.write(xlsx_bytes)
-            download_url_csv = url_for("apps.batch_download", job_id=job_id, ext="csv")
-            download_url_xlsx = url_for("apps.batch_download", job_id=job_id, ext="xlsx")
+            download_url["csv"] = url_for("apps.batch_download", job_id=job_id, ext="csv")
+            download_url["xlsx"] = url_for("apps.batch_download", job_id=job_id, ext="xlsx")
 
         if request.headers.get("HX-Request"):
             return render_template(
                 "partials/batch_results.html",
                 table=table,
-                download_url_csv=download_url_csv,
-                download_url_xlsx=download_url_xlsx,
+                download_url=download_url,
             )
 
     return render_template(
         "apps/batch.html",
         table=table,
-        download_url_csv=download_url_csv,
-        download_url_xlsx=download_url_xlsx,
+        download_url=download_url,
     )
 
 

--- a/website/templates/partials/batch_results.html
+++ b/website/templates/partials/batch_results.html
@@ -9,10 +9,10 @@
     {% endfor %}
   </tbody>
 </table>
-{% if download_url_csv %}
-<a href="{{ download_url_csv }}" class="btn btn-success">Descargar CSV</a>
+{% if download_url.csv %}
+<a href="{{ download_url.csv }}" class="btn btn-success">Descargar CSV</a>
 {% endif %}
-{% if download_url_xlsx %}
-<a href="{{ download_url_xlsx }}" class="btn btn-success ms-2">Descargar Excel</a>
+{% if download_url.xlsx %}
+<a href="{{ download_url.xlsx }}" class="btn btn-success ms-2">Descargar Excel</a>
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Summary
- remove unused `download_url_csv` and `download_url_xlsx`
- document and standardize `download_url` handling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'plotly')*


------
https://chatgpt.com/codex/tasks/task_e_689fc43f30048327aadb3e577721fd5a