### PR TITLE
Add frontend chart scripts for Erlang app

### DIFF
--- a/website/static/css/apps.css
+++ b/website/static/css/apps.css
@@ -63,3 +63,24 @@ main.container-xxl {
   font-size: 0.8rem;
   line-height: 1.2;
 }
+
+/* Erlang charts layout */
+.erlang-charts {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .erlang-charts {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.erlang-charts .card {
+  height: 100%;
+}
+
+.erlang-chart {
+  height: 300px;
+  margin: 0.5rem 0;
+}

--- a/website/static/js/apps/erlang.js
+++ b/website/static/js/apps/erlang.js
@@ -1,0 +1,34 @@
+// Plotly charts for Erlang page
+window.addEventListener('DOMContentLoaded', () => {
+  const dimEl = document.getElementById('erlang-dimension-bar');
+  if (dimEl && dimEl.dataset.bar && window.Plotly) {
+    try {
+      const data = JSON.parse(dimEl.dataset.bar);
+      const trace = {
+        type: 'bar',
+        x: ['Actual', 'Recomendado'],
+        y: [data.current, data.recommended],
+        marker: {
+          color: ['#0d6efd', '#198754'],
+        },
+      };
+      const layout = {
+        margin: { t: 10, r: 10, b: 40, l: 40 },
+        yaxis: { title: 'Agentes' },
+      };
+      Plotly.react(dimEl, [trace], layout, { responsive: true });
+    } catch (e) {
+      console.error('Failed to render dimension bar', e);
+    }
+  }
+
+  const sensEl = document.getElementById('erlang-sensitivity');
+  if (sensEl && sensEl.dataset.figure && window.Plotly) {
+    try {
+      const fig = JSON.parse(sensEl.dataset.figure);
+      Plotly.react(sensEl, fig.data, fig.layout || {}, { responsive: true });
+    } catch (e) {
+      console.error('Failed to render sensitivity chart', e);
+    }
+  }
+});

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -89,58 +89,55 @@
   </div>
   {% endif %}
 </div>
-<!--
-SL: {{ (metrics.service_level * 100)|round(1) }}%
-ASA: {{ metrics.asa|round(2) }}
-Ocupación: {{ (metrics.occupancy * 100)|round(1) }}%
-Requeridos: {{ metrics.required_agents }}
--->
-
-<div class="card mb-4">
-  <div class="card-body">
-    <h3 class="mb-3">Análisis de Dimensionamiento</h3>
-    <div class="table-responsive">
-      <table class="table table-sm">
-        <thead>
-          <tr>
-            <th>Agentes Recomendados</th>
-            <th>Agentes Actuales</th>
-            <th>Diferencia</th>
-            <th>Llamadas/Agente Requerido</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{{ metrics.required_agents }}</td>
-            <td>{{ agents }}</td>
-            <td>{{ metrics.required_agents - agents }}</td>
-            <td>{{ (metrics.calls_per_agent_req or 0)|round(1) }}</td>
-          </tr>
-        </tbody>
-      </table>
+  <!--
+  SL: {{ (metrics.service_level * 100)|round(1) }}%
+  ASA: {{ metrics.asa|round(2) }}
+  Ocupación: {{ (metrics.occupancy * 100)|round(1) }}%
+  Requeridos: {{ metrics.required_agents }}
+  -->
+  {% if metrics.dimension_bar or metrics.sensitivity %}
+  <div class="erlang-charts mb-4">
+    {% if metrics.dimension_bar %}
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="mb-3">Análisis de Dimensionamiento</h3>
+        <div id="erlang-dimension-bar" class="erlang-chart mb-3" data-bar='{{ metrics.dimension_bar | tojson | safe }}'></div>
+        <div class="table-responsive">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>Agentes Recomendados</th>
+                <th>Agentes Actuales</th>
+                <th>Diferencia</th>
+                <th>Llamadas/Agente Requerido</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{{ metrics.required_agents }}</td>
+                <td>{{ agents }}</td>
+                <td>{{ metrics.required_agents - agents }}</td>
+                <td>{{ (metrics.calls_per_agent_req or 0)|round(1) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
+    {% endif %}
+    {% if metrics.sensitivity %}
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="mb-3">Sensibilidad</h3>
+        <div id="erlang-sensitivity" class="erlang-chart" data-figure='{{ metrics.sensitivity | tojson | safe }}'></div>
+      </div>
+    </div>
+    {% endif %}
   </div>
-</div>
-
-{% if figure_json %}
-<div class="card mb-4">
-  <div class="card-body">
-    <h3 class="mb-3">Sensibilidad</h3>
-    <div id="erlang-figure" data-figure='{{ figure_json | tojson | safe }}'></div>
-  </div>
-</div>
-<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-<script>
-  (function(){
-    const el = document.getElementById('erlang-figure');
-    if (el) {
-      const fig = JSON.parse(el.dataset.figure);
-      Plotly.react(el, fig.data, fig.layout);
-    }
-  })();
-</script>
-{% endif %}
-{% endif %}
+  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+  <script src="{{ url_for('static', filename='js/apps/erlang.js') }}"></script>
+  {% endif %}
+  {% endif %}
 
 <div class="accordion mb-4" id="metodologiaAccordion">
   <div class="accordion-item">


### PR DESCRIPTION
## Summary
- Render Erlang dimension and sensitivity charts with new erlang.js script
- Link script and restructure erlang.html to mount charts from metrics data
- Style Erlang chart containers for consistent layout

## Testing
- `pytest tests/test_top_k_patterns.py` *(fails: No module named 'flask_wtf')*


------
https://chatgpt.com/codex/tasks/task_e_689fd024d68483278a52f49e33dbc8e6