### PR TITLE
Load apps resources in main layout

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -11,6 +11,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/apps.css') }}">
 </head>
 <body>
     {% set is_public = request.endpoint in ['core.landing','core.index','core.checkout','core.subscribe'] %}
@@ -68,5 +69,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/apps_common.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `css/apps.css` and `js/apps_common.js` in the global base template

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Cannot import 'setuptools.build_meta')*


------
https://chatgpt.com/codex/tasks/task_e_689fd80196a08327b86db82a06ddf107