### PR TITLE
Implement responsive Erlang dashboard with Chart.js

### DIFF
--- a/tests/test_apps_erlang.py
+++ b/tests/test_apps_erlang.py
@@ -115,14 +115,15 @@ def test_erlang_metrics_mode(monkeypatch):
     )
     assert response.status_code == 200
     html = response.get_data(as_text=True)
-    assert 'SL:' in html
-    assert 'ASA:' in html
-    assert 'Ocupación:' in html
-    assert 'Requeridos:' in html
-    assert '80' in html
-    assert '20' in html
-    assert '50' in html
-    assert '5' in html
+    assert 'Service Level' in html
+    assert 'ASA' in html
+    assert 'Ocupación' in html
+    assert 'Liberados por agente' in html
+    assert 'Diferencia (recomendado - actual)' in html
+    assert '80.0' in html
+    assert '20.0' in html
+    assert '50.0' in html
+    assert '-5' in html
 
 
 def test_erlang_required_agents_mode(monkeypatch):
@@ -162,7 +163,7 @@ def test_erlang_required_agents_mode(monkeypatch):
     )
     assert response.status_code == 200
     html = response.get_data(as_text=True)
-    assert 'Requeridos' in html
+    assert 'Recomendados' in html
     assert '7' in html
 
 
@@ -245,12 +246,14 @@ def test_compute_erlang_structures(monkeypatch):
     }
     result = compute_erlang(payload)
     assert result["dimension_bar"] == {
-        "min": 3,
+        "min": 0,
         "max": 5,
         "actual": 3,
         "recomendado": 5,
     }
     assert result["sensitivity"]["agents"] == [3, 4, 5]
+    assert result["sensitivity"]["sl"] == [80.0, 80.0, 80.0]
+    assert result["sensitivity"]["asa"] == [10.0, 10.0, 10.0]
     assert len(result["download"]["csv_rows"]) == 5
     assert len(result["download"]["xlsx_rows"]) == 5
 

--- a/website/static/css/apps.css
+++ b/website/static/css/apps.css
@@ -84,3 +84,8 @@ main.container-xxl {
   height: 300px;
   margin: 0.5rem 0;
 }
+
+/* Consistent height for Erlang metric cards */
+.erlang-metric-card {
+  min-height: 110px;
+}

--- a/website/templates/apps/erlang.html
+++ b/website/templates/apps/erlang.html
@@ -13,9 +13,6 @@
   <a class="nav-link {{ 'active' if request.endpoint in ['apps.batch', 'apps.batch_download'] else '' }}" href="{{ url_for('apps.batch') }}">Batch</a>
 </nav>
 
-{% set agents = (form.agents or 0)|int %}
-{% set figure_json = metrics.sensitivity %}
-
 <div class="card mb-4">
   <div class="card-body">
     <form id="erlang-form" class="row g-3" method="post">
@@ -84,84 +81,95 @@
   </div>
 </div>
 
-{% if metrics %}
-<div class="metrics-grid mb-4">
-  <div class="metric-card {{ metrics.sl_class }}">
-    <h3>Service Level</h3>
-    <h2>{{ (metrics.service_level * 100)|round(1) }}%</h2>
+{% if result %}
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-5 g-3 mb-4">
+  <div class="col">
+    <div class="card text-center erlang-metric-card bg-success-subtle">
+      <div class="card-body d-flex flex-column justify-content-center">
+        <div class="fs-3">{% if result.service_level is not none %}{{ result.service_level }}%{% else %}—{% endif %}</div>
+        <div class="text-muted">Service Level</div>
+      </div>
+    </div>
   </div>
-  <div class="metric-card {{ metrics.asa_class }}">
-    <h3>ASA</h3>
-    <h2>{{ metrics.asa|round(2) }} seg</h2>
+  <div class="col">
+    <div class="card text-center erlang-metric-card bg-success-subtle">
+      <div class="card-body d-flex flex-column justify-content-center">
+        <div class="fs-3">{% if result.asa is not none %}{{ result.asa }}<span class="fs-6">s</span>{% else %}—{% endif %}</div>
+        <div class="text-muted">ASA</div>
+      </div>
+    </div>
   </div>
-  <div class="metric-card {{ metrics.occ_class }}">
-    <h3>Ocupación</h3>
-    <h2>{{ (metrics.occupancy * 100)|round(1) }}%</h2>
+  <div class="col">
+    <div class="card text-center erlang-metric-card bg-warning-subtle">
+      <div class="card-body d-flex flex-column justify-content-center">
+        <div class="fs-3">{% if result.occupancy is not none %}{{ result.occupancy }}%{% else %}—{% endif %}</div>
+        <div class="text-muted">Ocupación</div>
+      </div>
+    </div>
   </div>
-  {% if metrics.abandonment is defined %}
-  <div class="metric-card {{ metrics.abandon_class }}">
-    <h3>Abandono</h3>
-    <h2>{{ (metrics.abandonment * 100)|round(1) }}%</h2>
+  <div class="col">
+    <div class="card text-center erlang-metric-card bg-primary-subtle">
+      <div class="card-body d-flex flex-column justify-content-center">
+        <div class="fs-3">{% if result.liberados_por_agente is not none %}{{ result.liberados_por_agente }}{% else %}—{% endif %}</div>
+        <div class="text-muted">Liberados por agente</div>
+      </div>
+    </div>
   </div>
-  {% endif %}
-  <div class="metric-card {{ metrics.liberados_por_agente_class }}">
-    <h3>Liberados por agente</h3>
-    <h2>{{ (metrics.liberados_por_agente or 0)|round(1) }}</h2>
-  </div>
-  <div class="metric-card {{ metrics.agents_delta_class }}">
-    <h3>Diferencia (recomendado - actual)</h3>
-    <h2>{{ metrics.agents_delta }}</h2>
+  <div class="col">
+    <div class="card text-center erlang-metric-card bg-secondary-subtle">
+      <div class="card-body d-flex flex-column justify-content-center">
+        <div class="fs-3">{% if result.agents_delta is not none %}{{ result.agents_delta }}{% else %}—{% endif %}</div>
+        <div class="text-muted">Diferencia (recomendado - actual)</div>
+      </div>
+    </div>
   </div>
 </div>
-  <!--
-  SL: {{ (metrics.service_level * 100)|round(1) }}%
-  ASA: {{ metrics.asa|round(2) }}
-  Ocupación: {{ (metrics.occupancy * 100)|round(1) }}%
-  Requeridos: {{ metrics.required_agents }}
-  -->
-  {% if metrics.dimension_bar or metrics.sensitivity %}
-  <div class="erlang-charts mb-4">
-    {% if metrics.dimension_bar %}
-    <div class="card h-100">
-      <div class="card-body">
-        <h3 class="mb-3">Análisis de Dimensionamiento</h3>
-        <div id="erlang-dimension-bar" class="erlang-chart mb-3" data-bar='{{ metrics.dimension_bar | tojson | safe }}'></div>
-        <div class="table-responsive">
-          <table class="table table-sm">
-            <thead>
-              <tr>
-                <th>Agentes Recomendados</th>
-                <th>Agentes Actuales</th>
-                <th>Diferencia</th>
-                <th>Llamadas/Agente Requerido</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{{ metrics.required_agents }}</td>
-                <td>{{ agents }}</td>
-                <td>{{ metrics.required_agents - agents }}</td>
-                <td>{{ (metrics.calls_per_agent_req or 0)|round(1) }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+{% if result.dimension_bar or result.sensitivity %}
+<div class="erlang-charts mb-4">
+  {% if result.dimension_bar %}
+  <div class="card h-100">
+    <div class="card-body">
+      <h3 class="mb-3">Análisis de Dimensionamiento</h3>
+      <canvas id="dimensionChart" class="mb-3"></canvas>
+      <div class="table-responsive">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Recomendados</th>
+              <th>Actual</th>
+              <th>Diferencia</th>
+              <th>Llamadas/Agente Requerido</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{{ result.agents_recommended }}</td>
+              <td>{{ result.agents_current }}</td>
+              <td>{{ result.agents_delta }}</td>
+              <td>{% if result.calls_per_agent_req is not none %}{{ result.calls_per_agent_req }}{% else %}—{% endif %}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
-    {% endif %}
-    {% if metrics.sensitivity %}
-    <div class="card h-100">
-      <div class="card-body">
-        <h3 class="mb-3">Sensibilidad</h3>
-        <div id="erlang-sensitivity" class="erlang-chart" data-figure='{{ metrics.sensitivity | tojson | safe }}'></div>
-      </div>
-    </div>
-    {% endif %}
   </div>
-  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-  <script src="{{ url_for('static', filename='js/apps/erlang.js') }}"></script>
   {% endif %}
+  {% if result.sensitivity %}
+  <div class="card h-100">
+    <div class="card-body">
+      <h3 class="mb-3">Sensibilidad</h3>
+      <canvas id="sensitivityChart"></canvas>
+    </div>
+  </div>
   {% endif %}
+</div>
+<script>
+  window.ERLANG_RESULT = {{ result|tojson|safe if result else 'null' }};
+</script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='js/apps/erlang.js') }}"></script>
+{% endif %}
+{% endif %}
 
 <div class="accordion mb-4" id="metodologiaAccordion">
   <div class="accordion-item">


### PR DESCRIPTION
## Summary
- Format backend Erlang metrics with rounded values and build dimension bar and sensitivity datasets
- Rework Erlang template with responsive metric cards and Chart.js canvases
- Add Chart.js rendering logic and styling for consistent card height

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad051a10832792485d2e5ca46a56