### PR TITLE
feat: add solver progress tracking

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -20,6 +20,7 @@ from flask_wtf.csrf import CSRFError
 
 from ..utils.allowlist import verify_user
 from ..utils import kpis_core
+from ..scheduler import PROGRESS
 
 bp = Blueprint("core", __name__)
 
@@ -240,6 +241,12 @@ def resultados():
     session.pop("job_id", None)
 
     return render_template("resultados.html", resultado=resultado)
+
+
+@bp.route("/progress/<job_id>")
+@login_required
+def progress(job_id):
+    return jsonify({"percent": PROGRESS.get(job_id, 0)})
 
 
 @bp.route("/download/<job_id>")

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -4,9 +4,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const slowMsg = document.getElementById('slowMsg');
   const btnExcel = document.getElementById('btnExcel');
   const btnCharts = document.getElementById('btnCharts');
+  const progressBar = document.getElementById('progressBar');
+  const bar = progressBar ? progressBar.querySelector('.progress-bar') : null;
   let generateCharts = false;
+  let intervalId = null;
+  let jobId = null;
 
-  if (!form || !spinner || !slowMsg || !btnExcel || !btnCharts) return;
+  if (!form || !spinner || !slowMsg || !btnExcel || !btnCharts || !progressBar || !bar) return;
 
   form.addEventListener('submit', (e) => {
     generateCharts = e.submitter === btnCharts;
@@ -19,6 +23,30 @@ document.addEventListener('DOMContentLoaded', () => {
     btnExcel.disabled = true;
     btnCharts.disabled = true;
     spinner.classList.remove('d-none');
+    progressBar.classList.remove('d-none');
+    bar.style.width = '0%';
+
+    jobId = self.crypto?.randomUUID ? self.crypto.randomUUID() : Date.now().toString();
+    const hidden = document.createElement('input');
+    hidden.type = 'hidden';
+    hidden.name = 'job_id';
+    hidden.value = jobId;
+    form.appendChild(hidden);
+
+    intervalId = setInterval(() => {
+      fetch(`/progress/${jobId}`)
+        .then((r) => r.json())
+        .then((data) => {
+          const percent = data.percent || 0;
+          bar.style.width = `${percent}%`;
+          bar.setAttribute('aria-valuenow', percent);
+          if (percent >= 100) {
+            clearInterval(intervalId);
+            spinner.classList.add('d-none');
+          }
+        })
+        .catch(() => {});
+    }, 1000);
     setTimeout(() => slowMsg.classList.remove('d-none'), 10000);
   });
 

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -191,6 +191,10 @@
       <div class="text-warning-emphasis d-none" id="slowMsg">La generación está tardando más de lo esperado…</div>
     </div>
 
+    <div id="progressBar" class="progress d-none">
+      <div class="progress-bar" role="progressbar"></div>
+    </div>
+
   </form>
 
 <script src="{{ url_for('static', filename='js/generador.js') }}"></script>


### PR DESCRIPTION
## Summary
- add progress bar to generador template and poll updates
- expose `/progress/<job_id>` endpoint
- track solver progress server-side

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68a2b0d0843083278cfd17df8d951c59