### PR TITLE
Rename scheduler extension variable

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask
 from dotenv import load_dotenv
 
-from .extensions import csrf, scheduler
+from .extensions import csrf, scheduler_ext
 from .blueprints.core import bp as core_bp
 from .blueprints.apps import apps_bp
 
@@ -32,7 +32,7 @@ def create_app(config=None):
 
     # Extensions
     csrf.init_app(app)
-    scheduler.init_app(app)
+    scheduler_ext.init_app(app)
 
     # Blueprints
     app.register_blueprint(core_bp)

--- a/website/extensions/__init__.py
+++ b/website/extensions/__init__.py
@@ -11,4 +11,6 @@ class Scheduler:
         pass
 
 
-scheduler = Scheduler()
+scheduler_ext = Scheduler()
+
+__all__ = ["csrf", "scheduler_ext"]


### PR DESCRIPTION
## Summary
- Rename scheduler extension instance to `scheduler_ext` and export it
- Update app factory to use `scheduler_ext`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'PROGRESS' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68a2b478b8608327a7ec5148ee3579f3