### PR TITLE
Handle solver progress beyond time limit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import types
+
+# Ensure repository root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide a scheduler stub with PROGRESS to satisfy blueprint imports when tests
+# replace the module without defining it.
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(PROGRESS={}))
+
+# Stub optional heavy dependency with minimal Workbook implementation
+class _Sheet:
+    def append(self, row):
+        pass
+
+
+class _Workbook:
+    def __init__(self, *args, **kwargs):
+        self.active = _Sheet()
+
+    def save(self, *args, **kwargs):
+        pass
+
+
+def _load_workbook(*args, **kwargs):
+    return _Workbook()
+
+
+sys.modules.setdefault('openpyxl', types.SimpleNamespace(Workbook=_Workbook, load_workbook=_load_workbook))

--- a/tests/test_progress_endpoint.py
+++ b/tests/test_progress_endpoint.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import threading
+import time
+
+
+def test_progress_endpoint_reports_completion():
+    orig_scheduler = sys.modules.get('website.scheduler')
+    orig_core = sys.modules.get('website.blueprints.core')
+    orig_website = sys.modules.get('website')
+    stubbed = {}
+    try:
+        for mod in ['website.scheduler', 'website.blueprints.core', 'website']:
+            sys.modules.pop(mod, None)
+        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+        import types
+        stubbed_names = {
+            'plotly': types.SimpleNamespace(
+                graph_objects=types.SimpleNamespace(), express=types.SimpleNamespace()
+            ),
+            'plotly.graph_objects': types.SimpleNamespace(),
+            'plotly.express': types.SimpleNamespace(),
+            'sklearn': types.SimpleNamespace(
+                metrics=types.SimpleNamespace(
+                    mean_absolute_error=lambda *a, **k: 0,
+                    mean_squared_error=lambda *a, **k: 0,
+                )
+            ),
+            'sklearn.metrics': types.SimpleNamespace(
+                mean_absolute_error=lambda *a, **k: 0,
+                mean_squared_error=lambda *a, **k: 0,
+            ),
+            'seaborn': types.SimpleNamespace(set_theme=lambda *a, **k: None),
+            'scipy': types.SimpleNamespace(optimize=types.SimpleNamespace()),
+            'scipy.optimize': types.SimpleNamespace(),
+            'statsmodels': types.SimpleNamespace(
+                tsa=types.SimpleNamespace(
+                    holtwinters=types.SimpleNamespace(ExponentialSmoothing=object)
+                )
+            ),
+            'statsmodels.tsa': types.SimpleNamespace(
+                holtwinters=types.SimpleNamespace(ExponentialSmoothing=object)
+            ),
+            'statsmodels.tsa.holtwinters': types.SimpleNamespace(ExponentialSmoothing=object),
+        }
+        for name, module in stubbed_names.items():
+            stubbed[name] = sys.modules.get(name)
+            sys.modules[name] = module
+        from website import create_app
+        from website.scheduler import log_solver_progress, PROGRESS
+        app = create_app()
+        job_id = 'job1'
+        stop_event = threading.Event()
+        thread = threading.Thread(target=log_solver_progress, args=(1, stop_event, job_id))
+        thread.daemon = True
+        thread.start()
+        time.sleep(1.2)
+        with app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['user'] = 'tester'
+            resp = client.get(f'/progress/{job_id}')
+            assert resp.get_json()['percent'] == 99
+            stop_event.set()
+            thread.join()
+            resp = client.get(f'/progress/{job_id}')
+            assert resp.get_json()['percent'] == 100
+    finally:
+        if orig_scheduler is not None:
+            sys.modules['website.scheduler'] = orig_scheduler
+        else:
+            sys.modules.pop('website.scheduler', None)
+        if orig_core is not None:
+            sys.modules['website.blueprints.core'] = orig_core
+        else:
+            sys.modules.pop('website.blueprints.core', None)
+        if orig_website is not None:
+            sys.modules['website'] = orig_website
+        else:
+            sys.modules.pop('website', None)
+        for name, module in stubbed.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -111,12 +111,16 @@ def log_solver_progress(time_limit, stop_event, job_id=None):
     start = time.time()
     while not stop_event.is_set():
         elapsed = time.time() - start
-        percent = min(100, (elapsed / time_limit) * 100) if time_limit else 100
+        if time_limit:
+            if elapsed >= time_limit:
+                percent = 99
+            else:
+                percent = (elapsed / time_limit) * 100
+        else:
+            percent = 99
         if job_id is not None:
             PROGRESS[job_id] = percent
         print(f"[SOLVER] {percent:.0f}%")
-        if elapsed >= time_limit:
-            break
         time.sleep(1)
     if job_id is not None:
         PROGRESS[job_id] = 100


### PR DESCRIPTION
## Summary
- Keep solver progress loop running after time limit and cap reported progress at 99%
- Mark progress as 100% only once the solver thread ends
- Add regression test ensuring `/progress/<job_id>` reaches 100 only after completion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad0a6372388327ba6852101303783d