### PR TITLE
Enable configurable memory cap for pattern generation

### DIFF
--- a/legacy/app1.py
+++ b/legacy/app1.py
@@ -66,12 +66,24 @@ def _build_pattern(
     return pattern.flatten()
 
 
-def memory_limit_patterns(slots_per_day: int) -> int:
-    """Return how many patterns fit in roughly 4GB of RAM."""
+def memory_limit_patterns(slots_per_day: int, max_gb: float | None = None) -> int:
+    """Return how many patterns fit in memory.
+
+    Parameters
+    ----------
+    slots_per_day:
+        Number of slots in a 24 hour period.
+    max_gb:
+        Optional cap in gigabytes. When provided the calculation uses the
+        minimum between the available memory and ``max_gb``.
+    """
     if slots_per_day <= 0:
         return 0
     available = psutil.virtual_memory().available
-    cap = min(available, 4 * 1024 ** 3)
+    if max_gb is not None:
+        cap = min(available, max_gb * 1024 ** 3)
+    else:
+        cap = available
     return int(cap // (7 * slots_per_day))
 
 
@@ -245,7 +257,7 @@ def load_shift_patterns(
         base_slot_min = mins and min(mins) or 60
     slots_per_day = 24 * (60 // base_slot_min)
     if max_patterns is None:
-        max_patterns = memory_limit_patterns(slots_per_day)
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=None)
 
     shifts_coverage: Dict[str, np.ndarray] = {}
     unique_patterns: Dict[bytes, str] = {}
@@ -1019,7 +1031,7 @@ def generate_shifts_coverage_corrected(*, max_patterns: int | None = None, batch
         step = slot_minutes / 60
     slots_per_day = 24 * (60 // slot_minutes)
     if max_patterns is None:
-        max_patterns = memory_limit_patterns(slots_per_day)
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=None)
 
     start_hours = [h for h in np.arange(0, 24, step) if h <= 23.5]
 


### PR DESCRIPTION
## Summary
- Add `max_gb` parameter to `memory_limit_patterns` allowing optional memory cap
- Update pattern-generation calls to pass `max_gb` argument explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad27b436d883278bbd9369478f54b1