### PR TITLE
Expose CBC solver thread count

### DIFF
--- a/legacy/app1.py
+++ b/legacy/app1.py
@@ -589,6 +589,16 @@ df = pd.read_excel(uploaded)
 st.sidebar.header("⚙️ Configuración")
 MAX_ITER = int(st.sidebar.number_input("Iteraciones máximas", 10, 100, 30))
 TIME_SOLVER = float(st.sidebar.number_input("Tiempo solver (s)", 60, 600, 240))
+SOLVER_THREADS = int(
+    st.sidebar.number_input(
+        "Threads solver (PuLP)",
+        min_value=1,
+        max_value=int(os.cpu_count() or 1),
+        value=int(os.cpu_count() or 1),
+        step=1,
+        help="Número de hilos para CBC solver",
+    )
+)
 TARGET_COVERAGE = float(st.sidebar.slider("Cobertura objetivo (%)", 95, 100, 98))
 VERBOSE = st.sidebar.checkbox("Modo verbose/debug", False)
 
@@ -1444,7 +1454,7 @@ def optimize_single_type(shifts, demand_matrix, shift_type):
         prob += total_excess <= demand_matrix.sum() * 0.05
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
     
     # Extraer resultados
     assignments = {}
@@ -1614,7 +1624,7 @@ def optimize_with_precision_targeting(shifts_coverage, demand_matrix):
             msg=0,
             timeLimit=TIME_SOLVER,
             gapRel=0.02,   # 2% gap de optimalidad (más flexible)
-            threads=1,
+            threads=SOLVER_THREADS,
             presolve=1,
             cuts=1
         )
@@ -1735,7 +1745,7 @@ def optimize_ft_no_excess(ft_shifts, demand_matrix):
             prob += coverage <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
     
     ft_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1793,7 +1803,7 @@ def optimize_pt_complete(pt_shifts, remaining_demand):
             prob += coverage - excess_vars[(day, hour)] <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
     
     pt_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1851,7 +1861,7 @@ def optimize_with_relaxed_constraints(shifts_coverage, demand_matrix):
         prob += total_agents <= int(total_demand / 3)
         
         # Resolver con configuración básica
-        prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=1))
+        prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
         
         assignments = {}
         if prob.status == pulp.LpStatusOptimal:
@@ -2042,7 +2052,7 @@ def optimize_direct_improved(shifts_coverage, demand_matrix):
             msg=0,
             timeLimit=TIME_SOLVER,
             gapRel=0.02,  # 2% gap de optimalidad
-            threads=1
+            threads=SOLVER_THREADS
         )
         prob.solve(solver)
         
@@ -2118,7 +2128,7 @@ def optimize_single_type_improved(shifts_coverage, demand_matrix, shift_type):
     prob += total_excess <= demand_matrix.sum() * 0.15
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
     
     assignments = {}
     if prob.status == pulp.LpStatusOptimal:

--- a/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
+++ b/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
@@ -589,6 +589,16 @@ df = pd.read_excel(uploaded)
 st.sidebar.header("⚙️ Configuración")
 MAX_ITER = int(st.sidebar.number_input("Iteraciones máximas", 10, 100, 30))
 TIME_SOLVER = float(st.sidebar.number_input("Tiempo solver (s)", 60, 600, 240))
+SOLVER_THREADS = int(
+    st.sidebar.number_input(
+        "Threads solver (PuLP)",
+        min_value=1,
+        max_value=int(os.cpu_count() or 1),
+        value=int(os.cpu_count() or 1),
+        step=1,
+        help="Número de hilos para CBC solver",
+    )
+)
 TARGET_COVERAGE = float(st.sidebar.slider("Cobertura objetivo (%)", 95, 100, 98))
 VERBOSE = st.sidebar.checkbox("Modo verbose/debug", False)
 
@@ -1444,7 +1454,7 @@ def optimize_single_type(shifts, demand_matrix, shift_type):
         prob += total_excess <= demand_matrix.sum() * 0.05
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
     
     # Extraer resultados
     assignments = {}
@@ -1614,7 +1624,7 @@ def optimize_with_precision_targeting(shifts_coverage, demand_matrix):
             msg=0,
             timeLimit=TIME_SOLVER,
             gapRel=0.02,   # 2% gap de optimalidad (más flexible)
-            threads=1,
+            threads=SOLVER_THREADS,
             presolve=1,
             cuts=1
         )
@@ -1735,7 +1745,7 @@ def optimize_ft_no_excess(ft_shifts, demand_matrix):
             prob += coverage <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
     
     ft_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1793,7 +1803,7 @@ def optimize_pt_complete(pt_shifts, remaining_demand):
             prob += coverage - excess_vars[(day, hour)] <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
     
     pt_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1851,7 +1861,7 @@ def optimize_with_relaxed_constraints(shifts_coverage, demand_matrix):
         prob += total_agents <= int(total_demand / 3)
         
         # Resolver con configuración básica
-        prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=1))
+        prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
         
         assignments = {}
         if prob.status == pulp.LpStatusOptimal:
@@ -2042,7 +2052,7 @@ def optimize_direct_improved(shifts_coverage, demand_matrix):
             msg=0,
             timeLimit=TIME_SOLVER,
             gapRel=0.02,  # 2% gap de optimalidad
-            threads=1
+            threads=SOLVER_THREADS
         )
         prob.solve(solver)
         
@@ -2118,7 +2128,7 @@ def optimize_single_type_improved(shifts_coverage, demand_matrix, shift_type):
     prob += total_excess <= demand_matrix.sum() * 0.15
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=1))
+    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
     
     assignments = {}
     if prob.status == pulp.LpStatusOptimal:


### PR DESCRIPTION
## Summary
- allow specifying CBC solver threads via Streamlit sidebar in legacy apps
- add `solver_threads` Flask config and use it in CBC solver calls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad27b9e4b88327adc8ef9f0791a57c