### PR TITLE
feat: add configurable memory cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,15 +216,16 @@ for a complete example.
 
 `load_shift_patterns()` and the internal `generate_shifts_coverage_optimized()`
 functions accept an optional `max_patterns` argument. When omitted the loader
-now estimates how many patterns fit in roughly 4&nbsp;GB of the available
-memory and caps generation automatically.  Patterns are generated and solved
-in batches (2000 patterns by default), sorted by a quick heuristic score, so even 50&nbsp;000+ combinations
-can be handled without exhausting RAM.  `generate_shifts_coverage_optimized()`
-still honours the `batch_size` option to emit patterns in smaller chunks.
-The configuration also exposes a `K` parameter that bounds how many of the
-best scoring patterns are kept in memory.  A heap is used internally to retain
-only the top `K` entries, discarding lower scored ones to further reduce the
-memory footprint.
+estimates how many patterns fit in memory and caps generation automatically.
+The calculation can be limited via the `max_memory_gb` configuration value
+(``None`` uses all available RAM).  Patterns are generated and solved in
+batches (2000 patterns by default), sorted by a quick heuristic score, so even
+50&nbsp;000+ combinations can be handled without exhausting RAM.
+`generate_shifts_coverage_optimized()` still honours the `batch_size` option to
+emit patterns in smaller chunks. The configuration also exposes a `K` parameter
+that bounds how many of the best scoring patterns are kept in memory.  A heap
+is used internally to retain only the top `K` entries, discarding lower scored
+ones to further reduce the memory footprint.
 
 ## Memory-aware Generation
 

--- a/legacy/app1.py
+++ b/legacy/app1.py
@@ -75,7 +75,8 @@ def memory_limit_patterns(slots_per_day: int, max_gb: float | None = None) -> in
         Number of slots in a 24 hour period.
     max_gb:
         Optional cap in gigabytes. When provided the calculation uses the
-        minimum between the available memory and ``max_gb``.
+        minimum between the available memory and ``max_gb``. If ``max_gb`` is
+        ``None`` all available memory is used.
     """
     if slots_per_day <= 0:
         return 0
@@ -257,7 +258,10 @@ def load_shift_patterns(
         base_slot_min = mins and min(mins) or 60
     slots_per_day = 24 * (60 // base_slot_min)
     if max_patterns is None:
-        max_patterns = memory_limit_patterns(slots_per_day, max_gb=None)
+        max_gb = cfg.get("max_memory_gb")
+        if isinstance(max_gb, str) and not max_gb.strip():
+            max_gb = None
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=max_gb)
 
     shifts_coverage: Dict[str, np.ndarray] = {}
     unique_patterns: Dict[bytes, str] = {}
@@ -1041,7 +1045,10 @@ def generate_shifts_coverage_corrected(*, max_patterns: int | None = None, batch
         step = slot_minutes / 60
     slots_per_day = 24 * (60 // slot_minutes)
     if max_patterns is None:
-        max_patterns = memory_limit_patterns(slots_per_day, max_gb=None)
+        max_gb = template_cfg.get("max_memory_gb")
+        if isinstance(max_gb, str) and not max_gb.strip():
+            max_gb = None
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=max_gb)
 
     start_hours = [h for h in np.arange(0, 24, step) if h <= 23.5]
 

--- a/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
+++ b/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
@@ -75,7 +75,8 @@ def memory_limit_patterns(slots_per_day: int, max_gb: float | None = None) -> in
         Number of slots in a day.
     max_gb:
         Optional memory cap in gigabytes. If provided, ``available`` memory is
-        capped to ``max_gb`` before calculating the limit.
+        capped to ``max_gb`` before calculating the limit. If ``max_gb`` is
+        ``None`` all available memory is used.
     """
     if slots_per_day <= 0:
         return 0
@@ -257,7 +258,10 @@ def load_shift_patterns(
         base_slot_min = mins and min(mins) or 60
     slots_per_day = 24 * (60 // base_slot_min)
     if max_patterns is None:
-        max_patterns = memory_limit_patterns(slots_per_day, max_gb=None)
+        max_gb = cfg.get("max_memory_gb")
+        if isinstance(max_gb, str) and not max_gb.strip():
+            max_gb = None
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=max_gb)
 
     shifts_coverage: Dict[str, np.ndarray] = {}
     unique_patterns: Dict[bytes, str] = {}
@@ -1041,7 +1045,10 @@ def generate_shifts_coverage_corrected(*, max_patterns: int | None = None, batch
         step = slot_minutes / 60
     slots_per_day = 24 * (60 // slot_minutes)
     if max_patterns is None:
-        max_patterns = memory_limit_patterns(slots_per_day, max_gb=None)
+        max_gb = template_cfg.get("max_memory_gb")
+        if isinstance(max_gb, str) and not max_gb.strip():
+            max_gb = None
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=max_gb)
 
     start_hours = [h for h in np.arange(0, 24, step) if h <= 23.5]
 

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -90,6 +90,9 @@ def generador():
         for key, value in request.form.items():
             if key in {"csrf_token", "generate_charts"}:
                 continue
+            if value == "":
+                config[key] = None
+                continue
             low = value.lower()
             if low in {"on", "true", "1"}:
                 config[key] = True

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -70,6 +70,7 @@ DEFAULT_CONFIG = {
     "critical_bonus": 2.0,
     "iterations": 30,
     "solver_threads": os.cpu_count() or 1,
+    "max_memory_gb": None,  # None uses all available memory
     "max_patterns": None,
     "batch_size": 2000,
     "quality_threshold": 0,
@@ -137,7 +138,8 @@ def memory_limit_patterns(slots_per_day, max_gb=None):
     """Return the max number of patterns that fit in memory.
 
     ``max_gb`` caps the available memory (in gigabytes) used for the
-    calculation when provided.
+    calculation when provided. When ``max_gb`` is ``None`` all available
+    memory is considered.
     """
     if slots_per_day <= 0:
         return 0
@@ -264,7 +266,10 @@ def load_shift_patterns(cfg, *, start_hours=None, break_from_start=2.0,
     base_slot_min = slot_duration_minutes or 60
     slots_per_day = 24 * (60 // base_slot_min)
     if max_patterns is None:
-        max_patterns = memory_limit_patterns(slots_per_day, max_gb=None)
+        max_gb = cfg.get("max_memory_gb")
+        if isinstance(max_gb, str) and not max_gb.strip():
+            max_gb = None
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=max_gb)
     shifts_coverage = {}
     unique_patterns = {}
     for shift in data.get("shifts", []):

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -153,6 +153,11 @@
                 <label class="form-label">Iteraciones</label>
                 <input type="number" class="form-control" name="iterations" value="30">
               </div>
+              <div class="col-md-3">
+                <label class="form-label">Memoria máx. (GB)</label>
+                <input type="number" step="0.1" min="0" class="form-control" name="max_memory_gb" placeholder="Ej. 4">
+                <div class="form-text">Dejar vacío para usar toda la memoria disponible.</div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- expose new `max_memory_gb` option in default config and HTML form
- pass memory cap to `memory_limit_patterns` across scheduler and legacy modules
- document that `None` uses all available RAM

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad2cbb84bc832787dbec6e7e1311ef