### PR TITLE
Expose solver solver_threads controls across interfaces

### DIFF
--- a/scripts/scheduler_cli.py
+++ b/scripts/scheduler_cli.py
@@ -1,0 +1,29 @@
+import argparse
+import os
+
+from website.scheduler import run_complete_optimization
+
+
+def positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError("solver_threads must be >= 1")
+    return ivalue
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run scheduling optimization")
+    parser.add_argument("excel", help="Path to Excel demand file")
+    parser.add_argument(
+        "--solver_threads",
+        type=positive_int,
+        default=os.cpu_count() or 1,
+        help="Number of CBC solver threads",
+    )
+    args = parser.parse_args()
+    with open(args.excel, "rb") as f:
+        run_complete_optimization(f, config={"solver_threads": args.solver_threads})
+
+
+if __name__ == "__main__":
+    main()

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -80,11 +80,12 @@ def register():
 @bp.route("/generador", methods=["GET", "POST"])
 @login_required
 def generador():
+    default_threads = os.cpu_count() or 1
     if request.method == "POST":
         excel_file = request.files.get("excel")
         if not excel_file:
             flash("Se requiere un archivo Excel", "warning")
-            return render_template("generador.html"), 400
+            return render_template("generador.html", default_threads=default_threads), 400
 
         config = {}
         for key, value in request.form.items():
@@ -157,7 +158,7 @@ def generador():
 
         return redirect(url_for("core.resultados"))
 
-    return render_template("generador.html")
+    return render_template("generador.html", default_threads=default_threads)
 
 
 @bp.route("/resultados")

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -98,6 +98,12 @@ def merge_config(cfg=None):
         pass
     if cfg:
         merged.update({k: v for k, v in cfg.items() if v is not None})
+    try:
+        merged["solver_threads"] = int(merged.get("solver_threads", 1))
+    except (TypeError, ValueError):
+        merged["solver_threads"] = 1
+    if merged["solver_threads"] < 1:
+        raise ValueError("solver_threads must be >= 1")
     return merged
 
 

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -153,6 +153,10 @@
                 <label class="form-label">Iteraciones</label>
                 <input type="number" class="form-control" name="iterations" value="30">
               </div>
+              <div class="col-md-3">
+                <label class="form-label">Threads solver</label>
+                <input type="number" min="1" class="form-control" name="solver_threads" value="{{ default_threads }}">
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Allow Flask generator form to set `solver_threads`
- Validate `solver_threads` in scheduler config and CLI
- Add command line utility to run optimization with custom solver threads

## Testing
- `pip install -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ad2cc029048327b5e99890e54e5fbd