### PR TITLE
Add configurable CBC solver logging and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ This project creates optimized work schedules using Flask.
    Estas opciones inician un único worker para evitar duplicar la memoria.
 
 
-4. The generator request times out after **240 s** by default. To use a different value set the `data-timeout` attribute (milliseconds) on the `<form id="genForm">` element in `generador.html`.
-5. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
-6. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
+4. `solver_time` sets the CBC time limit in seconds. Leave it blank (`None`) to run without a limit. Use `solver_msg=1` to display progress or `0` to hide it.
+5. The generator request times out after **240 s** by default. To use a different value set the `data-timeout` attribute (milliseconds) on the `<form id="genForm">` element in `generador.html`.
+6. Choose the **JEAN** profile from the sidebar to minimise the sum of excess and deficit while keeping coverage near 100%.
+7. Select **JEAN Personalizado** to choose the working days, hours per day and break placement. All other solver parameters use the JEAN profile automatically.
 
 ## Allowlist
 

--- a/legacy/app1.py
+++ b/legacy/app1.py
@@ -600,7 +600,9 @@ df = pd.read_excel(uploaded)
 # ——————————————————————————————————————————————————————————————
 st.sidebar.header("⚙️ Configuración")
 MAX_ITER = int(st.sidebar.number_input("Iteraciones máximas", 10, 100, 30))
-TIME_SOLVER = float(st.sidebar.number_input("Tiempo solver (s)", 60, 600, 240))
+TIME_SOLVER = st.sidebar.number_input("Tiempo solver (s)", min_value=0, max_value=600, value=0)
+TIME_SOLVER = None if TIME_SOLVER == 0 else float(TIME_SOLVER)
+SOLVER_MSG = st.sidebar.selectbox("Mostrar progreso solver", [1, 0], index=0)
 SOLVER_THREADS = int(
     st.sidebar.number_input(
         "Threads solver (PuLP)",
@@ -1466,7 +1468,10 @@ def optimize_single_type(shifts, demand_matrix, shift_type):
         prob += total_excess <= demand_matrix.sum() * 0.05
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     # Extraer resultados
     assignments = {}
@@ -1632,14 +1637,16 @@ def optimize_with_precision_targeting(shifts_coverage, demand_matrix):
         status_text.text("⚡ Ejecutando solver de precisión...")
         
         # Solver con configuración más flexible
-        solver = pulp.PULP_CBC_CMD(
-            msg=0,
-            timeLimit=TIME_SOLVER,
-            gapRel=0.02,   # 2% gap de optimalidad (más flexible)
-            threads=SOLVER_THREADS,
-            presolve=1,
-            cuts=1
-        )
+        solver_kwargs = {
+            "msg": SOLVER_MSG,
+            "threads": SOLVER_THREADS,
+            "gapRel": 0.02,   # 2% gap de optimalidad (más flexible)
+            "presolve": 1,
+            "cuts": 1,
+        }
+        if TIME_SOLVER is not None:
+            solver_kwargs["timeLimit"] = TIME_SOLVER
+        solver = pulp.PULP_CBC_CMD(**solver_kwargs)
         prob.solve(solver)
         
         # Extraer solución
@@ -1757,7 +1764,10 @@ def optimize_ft_no_excess(ft_shifts, demand_matrix):
             prob += coverage <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER // 2
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     ft_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1815,7 +1825,10 @@ def optimize_pt_complete(pt_shifts, remaining_demand):
             prob += coverage - excess_vars[(day, hour)] <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER // 2
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     pt_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1873,7 +1886,10 @@ def optimize_with_relaxed_constraints(shifts_coverage, demand_matrix):
         prob += total_agents <= int(total_demand / 3)
         
         # Resolver con configuración básica
-        prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+        solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+        if TIME_SOLVER is not None:
+            solver_kwargs["timeLimit"] = TIME_SOLVER // 2
+        prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
         
         assignments = {}
         if prob.status == pulp.LpStatusOptimal:
@@ -2060,12 +2076,14 @@ def optimize_direct_improved(shifts_coverage, demand_matrix):
         status_text.text("⚡ Resolviendo optimización...")
         
         # Resolver con configuración optimizada
-        solver = pulp.PULP_CBC_CMD(
-            msg=0,
-            timeLimit=TIME_SOLVER,
-            gapRel=0.02,  # 2% gap de optimalidad
-            threads=SOLVER_THREADS
-        )
+        solver_kwargs = {
+            "msg": SOLVER_MSG,
+            "threads": SOLVER_THREADS,
+            "gapRel": 0.02,  # 2% gap de optimalidad
+        }
+        if TIME_SOLVER is not None:
+            solver_kwargs["timeLimit"] = TIME_SOLVER
+        solver = pulp.PULP_CBC_CMD(**solver_kwargs)
         prob.solve(solver)
         
         # Extraer solución
@@ -2140,7 +2158,10 @@ def optimize_single_type_improved(shifts_coverage, demand_matrix, shift_type):
     prob += total_excess <= demand_matrix.sum() * 0.15
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     assignments = {}
     if prob.status == pulp.LpStatusOptimal:

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -90,6 +90,9 @@ def generador():
         for key, value in request.form.items():
             if key in {"csrf_token", "generate_charts"}:
                 continue
+            if value == "":
+                config[key] = None
+                continue
             low = value.lower()
             if low in {"on", "true", "1"}:
                 config[key] = True

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -62,7 +62,8 @@ def single_model(func):
 # Default configuration values used when no override is supplied
 DEFAULT_CONFIG = {
     # Streamlit legacy defaults from ``legacy/app1.py``
-    "TIME_SOLVER": 240,
+    "solver_time": None,
+    "solver_msg": 1,
     "TARGET_COVERAGE": 98.0,
     "agent_limit_factor": 12,
     "excess_penalty": 2.0,
@@ -1221,7 +1222,6 @@ def optimize_with_precision_targeting(shifts_coverage, demand_matrix, *, cfg=Non
     print(f"[PRECISION] Demanda total: {demand_matrix.sum()}")
 
     cfg = merge_config(cfg)
-    TIME_SOLVER = cfg["TIME_SOLVER"]
     agent_limit_factor = cfg["agent_limit_factor"]
     excess_penalty = cfg["excess_penalty"]
     peak_bonus = cfg["peak_bonus"]
@@ -1420,7 +1420,7 @@ def optimize_ft_no_excess(ft_shifts, demand_matrix, *, cfg=None):
     """Linear program focusing on full-time coverage only."""
     cfg = merge_config(cfg)
     agent_limit_factor = cfg["agent_limit_factor"]
-    TIME_SOLVER = cfg["TIME_SOLVER"]
+    solver_time = cfg.get("solver_time")
     if not ft_shifts:
         return {}
     prob = pl.LpProblem("FT_No_Excess", pl.LpMinimize)
@@ -1444,7 +1444,10 @@ def optimize_ft_no_excess(ft_shifts, demand_matrix, *, cfg=None):
             demand = demand_matrix[d, h]
             prob += coverage + deficit_vars[(d, h)] >= demand
             prob += coverage <= demand
-    prob.solve(pl.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=cfg["solver_threads"]))
+    solver_kwargs = {"msg": cfg.get("solver_msg", 1), "threads": cfg["solver_threads"]}
+    if solver_time is not None:
+        solver_kwargs["timeLimit"] = solver_time // 2
+    prob.solve(pl.PULP_CBC_CMD(**solver_kwargs))
     assignments = {}
     if prob.status == pl.LpStatusOptimal:
         for s in ft_shifts:
@@ -1460,7 +1463,7 @@ def optimize_pt_complete(pt_shifts, remaining_demand, *, cfg=None):
     cfg = merge_config(cfg)
     agent_limit_factor = cfg["agent_limit_factor"]
     excess_penalty = cfg["excess_penalty"]
-    TIME_SOLVER = cfg["TIME_SOLVER"]
+    solver_time = cfg.get("solver_time")
     optimization_profile = cfg["optimization_profile"]
     if not pt_shifts or remaining_demand.sum() == 0:
         return {}
@@ -1490,7 +1493,10 @@ def optimize_pt_complete(pt_shifts, remaining_demand, *, cfg=None):
             demand = remaining_demand[d, h]
             prob += coverage + deficit_vars[(d, h)] >= demand
             prob += coverage - excess_vars[(d, h)] <= demand
-    prob.solve(pl.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=cfg["solver_threads"]))
+    solver_kwargs = {"msg": cfg.get("solver_msg", 1), "threads": cfg["solver_threads"]}
+    if solver_time is not None:
+        solver_kwargs["timeLimit"] = solver_time // 2
+    prob.solve(pl.PULP_CBC_CMD(**solver_kwargs))
     assignments = {}
     if prob.status == pl.LpStatusOptimal:
         for s in pt_shifts:
@@ -1644,7 +1650,10 @@ def solve_with_pulp(demand_matrix, patterns, config):
             prob += coverage_expr + deficit[(d, h)] >= demand
             prob += coverage_expr - excess[(d, h)] <= demand
 
-    solver = pl.PULP_CBC_CMD(msg=0, timeLimit=cfg["TIME_SOLVER"], threads=cfg["solver_threads"])
+    solver_kwargs = {"msg": cfg.get("solver_msg", 1), "threads": cfg["solver_threads"]}
+    if cfg.get("solver_time") is not None:
+        solver_kwargs["timeLimit"] = cfg["solver_time"]
+    solver = pl.PULP_CBC_CMD(**solver_kwargs)
     status = prob.solve(solver)
 
     assignments = {

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -124,7 +124,14 @@
             <div class="row g-3">
               <div class="col-md-3">
                 <label class="form-label">Tiempo del solver (s)</label>
-                <input type="number" class="form-control" name="solver_time" value="240">
+                <input type="number" class="form-control" name="solver_time" placeholder="Sin límite">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Mostrar progreso del solver</label>
+                <select class="form-select" name="solver_msg">
+                  <option value="1" selected>Sí</option>
+                  <option value="0">No</option>
+                </select>
               </div>
               <div class="col-md-3">
                 <label class="form-label">Cobertura objetivo (%)</label>


### PR DESCRIPTION
## Summary
- allow configuring `solver_msg` and `solver_time` with sane defaults
- expose solver controls in web and legacy UIs
- document solver options and handle empty form values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad2cc8185483279fa4cd2bf4768ec2