### PR TITLE
Add configurable solver time and logging options

### DIFF
--- a/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
+++ b/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
@@ -604,7 +604,10 @@ df = pd.read_excel(uploaded)
 # ——————————————————————————————————————————————————————————————
 st.sidebar.header("⚙️ Configuración")
 MAX_ITER = int(st.sidebar.number_input("Iteraciones máximas", 10, 100, 30))
-TIME_SOLVER = float(st.sidebar.number_input("Tiempo solver (s)", 60, 600, 240))
+_solver_time = st.sidebar.number_input(
+    "Solver time (0 = sin límite)", min_value=0, max_value=600, value=0
+)
+TIME_SOLVER = None if _solver_time == 0 else float(_solver_time)
 SOLVER_THREADS = int(
     st.sidebar.number_input(
         "Threads solver (PuLP)",
@@ -615,6 +618,7 @@ SOLVER_THREADS = int(
         help="Número de hilos para CBC solver",
     )
 )
+SOLVER_MSG = st.sidebar.selectbox("Mostrar progreso solver", [1, 0], index=0)
 TARGET_COVERAGE = float(st.sidebar.slider("Cobertura objetivo (%)", 95, 100, 98))
 VERBOSE = st.sidebar.checkbox("Modo verbose/debug", False)
 
@@ -1473,7 +1477,10 @@ def optimize_single_type(shifts, demand_matrix, shift_type):
         prob += total_excess <= demand_matrix.sum() * 0.05
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     # Extraer resultados
     assignments = {}
@@ -1639,14 +1646,16 @@ def optimize_with_precision_targeting(shifts_coverage, demand_matrix):
         status_text.text("⚡ Ejecutando solver de precisión...")
         
         # Solver con configuración más flexible
-        solver = pulp.PULP_CBC_CMD(
-            msg=0,
-            timeLimit=TIME_SOLVER,
-            gapRel=0.02,   # 2% gap de optimalidad (más flexible)
-            threads=SOLVER_THREADS,
-            presolve=1,
-            cuts=1
-        )
+        solver_kwargs = {
+            "msg": SOLVER_MSG,
+            "threads": SOLVER_THREADS,
+            "gapRel": 0.02,   # 2% gap de optimalidad (más flexible)
+            "presolve": 1,
+            "cuts": 1,
+        }
+        if TIME_SOLVER is not None:
+            solver_kwargs["timeLimit"] = TIME_SOLVER
+        solver = pulp.PULP_CBC_CMD(**solver_kwargs)
         prob.solve(solver)
         
         # Extraer solución
@@ -1764,7 +1773,10 @@ def optimize_ft_no_excess(ft_shifts, demand_matrix):
             prob += coverage <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER / 2
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     ft_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1822,7 +1834,10 @@ def optimize_pt_complete(pt_shifts, remaining_demand):
             prob += coverage - excess_vars[(day, hour)] <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER / 2
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     pt_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1880,7 +1895,10 @@ def optimize_with_relaxed_constraints(shifts_coverage, demand_matrix):
         prob += total_agents <= int(total_demand / 3)
         
         # Resolver con configuración básica
-        prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+        solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+        if TIME_SOLVER is not None:
+            solver_kwargs["timeLimit"] = TIME_SOLVER / 2
+        prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
         
         assignments = {}
         if prob.status == pulp.LpStatusOptimal:
@@ -2067,12 +2085,14 @@ def optimize_direct_improved(shifts_coverage, demand_matrix):
         status_text.text("⚡ Resolviendo optimización...")
         
         # Resolver con configuración optimizada
-        solver = pulp.PULP_CBC_CMD(
-            msg=0,
-            timeLimit=TIME_SOLVER,
-            gapRel=0.02,  # 2% gap de optimalidad
-            threads=SOLVER_THREADS
-        )
+        solver_kwargs = {
+            "msg": SOLVER_MSG,
+            "threads": SOLVER_THREADS,
+            "gapRel": 0.02,  # 2% gap de optimalidad
+        }
+        if TIME_SOLVER is not None:
+            solver_kwargs["timeLimit"] = TIME_SOLVER
+        solver = pulp.PULP_CBC_CMD(**solver_kwargs)
         prob.solve(solver)
         
         # Extraer solución
@@ -2147,7 +2167,10 @@ def optimize_single_type_improved(shifts_coverage, demand_matrix, shift_type):
     prob += total_excess <= demand_matrix.sum() * 0.15
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": SOLVER_MSG, "threads": SOLVER_THREADS}
+    if TIME_SOLVER is not None:
+        solver_kwargs["timeLimit"] = TIME_SOLVER
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     assignments = {}
     if prob.status == pulp.LpStatusOptimal:


### PR DESCRIPTION
## Summary
- allow unlimited solver time via `Solver time (0 = sin límite)` option
- add `Mostrar progreso solver` selector to toggle CBC solver logs
- route all solver invocations through shared `solver_kwargs` honoring time and message settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad30bc4c5c8327a2d41bbba10a28ca