### PR TITLE
Add configurable memory limit

### DIFF
--- a/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
+++ b/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
@@ -258,10 +258,7 @@ def load_shift_patterns(
         base_slot_min = mins and min(mins) or 60
     slots_per_day = 24 * (60 // base_slot_min)
     if max_patterns is None:
-        max_gb = cfg.get("max_memory_gb")
-        if isinstance(max_gb, str) and not max_gb.strip():
-            max_gb = None
-        max_patterns = memory_limit_patterns(slots_per_day, max_gb=max_gb)
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=MAX_MEMORY_GB)
 
     shifts_coverage: Dict[str, np.ndarray] = {}
     unique_patterns: Dict[bytes, str] = {}
@@ -605,6 +602,13 @@ df = pd.read_excel(uploaded)
 st.sidebar.header("⚙️ Configuración")
 MAX_ITER = int(st.sidebar.number_input("Iteraciones máximas", 10, 100, 30))
 TIME_SOLVER = float(st.sidebar.number_input("Tiempo solver (s)", 60, 600, 240))
+MAX_MEMORY_GB = st.sidebar.number_input(
+    "Memoria máxima en GB (0 = sin límite)",
+    min_value=0.0,
+    max_value=64.0,
+    value=0.0,
+)
+MAX_MEMORY_GB = None if MAX_MEMORY_GB == 0 else float(MAX_MEMORY_GB)
 SOLVER_THREADS = int(
     st.sidebar.number_input(
         "Threads solver (PuLP)",
@@ -617,6 +621,7 @@ SOLVER_THREADS = int(
 )
 TARGET_COVERAGE = float(st.sidebar.slider("Cobertura objetivo (%)", 95, 100, 98))
 VERBOSE = st.sidebar.checkbox("Modo verbose/debug", False)
+cfg = {"max_memory_gb": MAX_MEMORY_GB}
 
 # Configuración de contratos
 st.sidebar.subheader("📋 Tipos de Contrato")
@@ -740,6 +745,8 @@ elif optimization_profile == "JEAN Personalizado":
         st.stop()
     try:
         template_cfg = json.load(template_file)
+        cfg.update(template_cfg)
+        cfg["max_memory_gb"] = MAX_MEMORY_GB
     except Exception as e:
         st.sidebar.error(f"Error al leer plantilla: {e}")
         st.stop()
@@ -1045,17 +1052,14 @@ def generate_shifts_coverage_corrected(*, max_patterns: int | None = None, batch
         step = slot_minutes / 60
     slots_per_day = 24 * (60 // slot_minutes)
     if max_patterns is None:
-        max_gb = template_cfg.get("max_memory_gb")
-        if isinstance(max_gb, str) and not max_gb.strip():
-            max_gb = None
-        max_patterns = memory_limit_patterns(slots_per_day, max_gb=max_gb)
+        max_patterns = memory_limit_patterns(slots_per_day, max_gb=MAX_MEMORY_GB)
 
     start_hours = [h for h in np.arange(0, 24, step) if h <= 23.5]
 
     # Perfil JEAN Personalizado: leer patrones desde JSON y retornar
     if optimization_profile == "JEAN Personalizado":
         shifts_coverage = load_shift_patterns(
-            template_cfg,
+            cfg,
             start_hours=start_hours,
             break_from_start=break_from_start,
             break_from_end=break_from_end,


### PR DESCRIPTION
## Summary
- add sidebar option to cap memory usage
- pass global MAX_MEMORY_GB to pattern generation helpers

## Testing
- `pytest` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ad30be76ec832783fe64892f3c8893