### PR TITLE
Ensure CBC solvers use configurable thread count

### DIFF
--- a/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
+++ b/legacy/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST.py
@@ -1473,7 +1473,8 @@ def optimize_single_type(shifts, demand_matrix, shift_type):
         prob += total_excess <= demand_matrix.sum() * 0.05
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": 0, "timeLimit": TIME_SOLVER, "threads": SOLVER_THREADS}
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     # Extraer resultados
     assignments = {}
@@ -1639,14 +1640,15 @@ def optimize_with_precision_targeting(shifts_coverage, demand_matrix):
         status_text.text("⚡ Ejecutando solver de precisión...")
         
         # Solver con configuración más flexible
-        solver = pulp.PULP_CBC_CMD(
-            msg=0,
-            timeLimit=TIME_SOLVER,
-            gapRel=0.02,   # 2% gap de optimalidad (más flexible)
-            threads=SOLVER_THREADS,
-            presolve=1,
-            cuts=1
-        )
+        solver_kwargs = {
+            "msg": 0,
+            "timeLimit": TIME_SOLVER,
+            "gapRel": 0.02,  # 2% gap de optimalidad (más flexible)
+            "threads": SOLVER_THREADS,
+            "presolve": 1,
+            "cuts": 1,
+        }
+        solver = pulp.PULP_CBC_CMD(**solver_kwargs)
         prob.solve(solver)
         
         # Extraer solución
@@ -1764,7 +1766,8 @@ def optimize_ft_no_excess(ft_shifts, demand_matrix):
             prob += coverage <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": 0, "timeLimit": TIME_SOLVER // 2, "threads": SOLVER_THREADS}
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     ft_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1822,7 +1825,8 @@ def optimize_pt_complete(pt_shifts, remaining_demand):
             prob += coverage - excess_vars[(day, hour)] <= demand
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": 0, "timeLimit": TIME_SOLVER // 2, "threads": SOLVER_THREADS}
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     pt_assignments = {}
     if prob.status == pulp.LpStatusOptimal:
@@ -1880,7 +1884,8 @@ def optimize_with_relaxed_constraints(shifts_coverage, demand_matrix):
         prob += total_agents <= int(total_demand / 3)
         
         # Resolver con configuración básica
-        prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER//2, threads=SOLVER_THREADS))
+        solver_kwargs = {"msg": 0, "timeLimit": TIME_SOLVER // 2, "threads": SOLVER_THREADS}
+        prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
         
         assignments = {}
         if prob.status == pulp.LpStatusOptimal:
@@ -2067,12 +2072,13 @@ def optimize_direct_improved(shifts_coverage, demand_matrix):
         status_text.text("⚡ Resolviendo optimización...")
         
         # Resolver con configuración optimizada
-        solver = pulp.PULP_CBC_CMD(
-            msg=0,
-            timeLimit=TIME_SOLVER,
-            gapRel=0.02,  # 2% gap de optimalidad
-            threads=SOLVER_THREADS
-        )
+        solver_kwargs = {
+            "msg": 0,
+            "timeLimit": TIME_SOLVER,
+            "gapRel": 0.02,  # 2% gap de optimalidad
+            "threads": SOLVER_THREADS,
+        }
+        solver = pulp.PULP_CBC_CMD(**solver_kwargs)
         prob.solve(solver)
         
         # Extraer solución
@@ -2147,7 +2153,8 @@ def optimize_single_type_improved(shifts_coverage, demand_matrix, shift_type):
     prob += total_excess <= demand_matrix.sum() * 0.15
     
     # Resolver
-    prob.solve(pulp.PULP_CBC_CMD(msg=0, timeLimit=TIME_SOLVER, threads=SOLVER_THREADS))
+    solver_kwargs = {"msg": 0, "timeLimit": TIME_SOLVER, "threads": SOLVER_THREADS}
+    prob.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
     
     assignments = {}
     if prob.status == pulp.LpStatusOptimal:

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -1305,14 +1305,15 @@ def optimize_with_precision_targeting(shifts_coverage, demand_matrix, *, cfg=Non
         print(f"[PRECISION] Total restricciones: {restriction_count}")
         print("[PRECISION] Configurando solver...")
 
-        solver = pl.PULP_CBC_CMD(
-            msg=1,
-            timeLimit=30,
-            gapRel=0.1,
-            threads=cfg["solver_threads"],
-            presolve=1,
-            cuts=0,
-        )
+        solver_kwargs = {
+            "msg": 1,
+            "timeLimit": 30,
+            "gapRel": 0.1,
+            "threads": cfg["solver_threads"],
+            "presolve": 1,
+            "cuts": 0,
+        }
+        solver = pl.PULP_CBC_CMD(**solver_kwargs)
 
         print("[PRECISION] Ejecutando solver PuLP...")
         prob.solve(solver)


### PR DESCRIPTION
## Summary
- Pass thread count through `solver_kwargs` for every CBC solver invocation in legacy generator
- Use `solver_kwargs` for CBC solver in website scheduler

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68ad30bfcaa483279f60715683fe8cc6