### PR TITLE
Handle scheduler errors and propagate

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -120,6 +120,12 @@ def generador():
         result, excel_bytes, csv_bytes = run_complete_optimization(
             excel_file, config=config, generate_charts=generate_charts
         )
+        if not result or result.get("error"):
+            error_msg = result.get("error") if isinstance(result, dict) else "Error desconocido"
+            if request.accept_mimetypes["application/json"] > request.accept_mimetypes["text/html"]:
+                return jsonify({"error": error_msg}), 500
+            flash(f"Ocurrió un error al procesar el archivo: {error_msg}", "danger")
+            return render_template("generador.html"), 500
 
         job_id = uuid.uuid4().hex
 

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -2069,3 +2069,4 @@ def run_complete_optimization(file_stream, config=None, generate_charts=False):
 
     except Exception as e:
         print(f"\u274C [SCHEDULER] ERROR CRÍTICO: {str(e)}")
+        return {"error": str(e)}, None, None


### PR DESCRIPTION
## Summary
- Return structured error info from `run_complete_optimization` when failures occur
- Surface scheduler errors through the generador blueprint to avoid hanging requests

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ad33ad65d08327a338e264860f925f