### PR TITLE
Handle solver timeouts and pass limit from form

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -117,9 +117,23 @@ def generador():
 
         from ..scheduler import run_complete_optimization
 
+        solver_time_val = request.form.get("solver_time")
+        if solver_time_val:
+            try:
+                config["solver_time"] = int(solver_time_val)
+            except ValueError:
+                config["solver_time"] = 300
+        else:
+            config.setdefault("solver_time", 300)
+
         result, excel_bytes, csv_bytes = run_complete_optimization(
             excel_file, config=config, generate_charts=generate_charts
         )
+        if result.get("status") == "TimeLimit":
+            flash(
+                "El solver alcanzó el límite de tiempo; se devolvió la mejor solución parcial disponible.",
+                "warning",
+            )
         if not result or result.get("error"):
             error_msg = result.get("error") if isinstance(result, dict) else "Error desconocido"
             if request.accept_mimetypes["application/json"] > request.accept_mimetypes["text/html"]:

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -13,6 +13,10 @@
     </div>
   </div>
 
+  {% if resultado and resultado.message %}
+  <div class="alert alert-warning">{{ resultado.message }}</div>
+  {% endif %}
+
   <!-- KPIs -->
   {% if resultado and resultado.metrics %}
   <div class="row g-3 mb-4 text-center">


### PR DESCRIPTION
## Summary
- Set default solver time to 300s and propagate status messages
- Ensure `solver_time` from form config and flash warning when limit hit
- Show partial-solution warning on results page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad3958108c83279601ed5aa4b65b73