### PR TITLE
Asegurar límite de tiempo por defecto en generador

### DIFF
--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -124,7 +124,7 @@ def generador():
             except ValueError:
                 config["solver_time"] = 300
         else:
-            config.setdefault("solver_time", 300)
+            config["solver_time"] = 300
 
         result, excel_bytes, csv_bytes = run_complete_optimization(
             excel_file, config=config, generate_charts=generate_charts


### PR DESCRIPTION
## Summary
- Establece explícitamente `config["solver_time"] = 300` cuando no se proporciona un tiempo de resolución, garantizando un límite numérico por defecto.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add29bac848327b3f1d6781b3d9c94