### PR TITLE
Toggle debug with FLASK_DEBUG and document reloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ This project creates optimized work schedules using Flask.
 
    When prompted on /generador upload the demand Excel file.
 
+   The reloader is disabled by default. Enable it during development with `FLASK_DEBUG=1`:
+   ```bash
+   FLASK_DEBUG=1 flask --app website.app run
+   ```
+
    Para despliegues de producción utiliza Gunicorn y establece las opciones
    recomendadas mediante `GUNICORN_CMD_ARGS`:
 

--- a/run.py
+++ b/run.py
@@ -1,6 +1,13 @@
+import os
+
 from website import create_app
 
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(debug=True, host="127.0.0.1", port=5000)
+    app.run(
+        debug=os.getenv("FLASK_DEBUG") == "1",
+        use_reloader=False,
+        host="127.0.0.1",
+        port=5000,
+    )


### PR DESCRIPTION
## Summary
- Read `FLASK_DEBUG` in `run.py` to toggle debug mode and disable the reloader
- Document how to enable the reloader in development using `FLASK_DEBUG=1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_68add5722a488327bdc163468ff4a638