### PR TITLE
Add job cancellation support via active job tracking

### DIFF
--- a/tests/test_contacto_route.py
+++ b/tests/test_contacto_route.py
@@ -5,7 +5,10 @@ import types
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+module = types.ModuleType("scheduler")
+module.active_jobs = {}
+module._stop_thread = lambda t: None
+sys.modules.setdefault('website.scheduler', module)
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_login_auth.py
+++ b/tests/test_login_auth.py
@@ -5,7 +5,10 @@ import types
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+module = types.ModuleType("scheduler")
+module.active_jobs = {}
+module._stop_thread = lambda t: None
+sys.modules.setdefault('website.scheduler', module)
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_navigation_dropdown.py
+++ b/tests/test_navigation_dropdown.py
@@ -5,7 +5,10 @@ import types
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+module = types.ModuleType("scheduler")
+module.active_jobs = {}
+module._stop_thread = lambda t: None
+sys.modules.setdefault('website.scheduler', module)
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_register_redirect.py
+++ b/tests/test_register_redirect.py
@@ -3,7 +3,10 @@ import sys
 import types
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+module = types.ModuleType("scheduler")
+module.active_jobs = {}
+module._stop_thread = lambda t: None
+sys.modules.setdefault('website.scheduler', module)
 
 from website import create_app
 

--- a/tests/test_subscribe_route.py
+++ b/tests/test_subscribe_route.py
@@ -7,7 +7,10 @@ import pytest
 from flask import template_rendered
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+module = types.ModuleType("scheduler")
+module.active_jobs = {}
+module._stop_thread = lambda t: None
+sys.modules.setdefault('website.scheduler', module)
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_subscribe_success_route.py
+++ b/tests/test_subscribe_success_route.py
@@ -7,7 +7,10 @@ import pytest
 from flask import template_rendered
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+module = types.ModuleType("scheduler")
+module.active_jobs = {}
+module._stop_thread = lambda t: None
+sys.modules.setdefault('website.scheduler', module)
 
 from website import create_app
 from website.utils import allowlist as allowlist_module


### PR DESCRIPTION
## Summary
- track optimization threads in a global `active_jobs` map
- allow cancelling jobs through new `/cancel` route
- clean up job registry when tasks finish and add coverage for cancellation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade91a33f48327abc0815dfd58b8c1