### PR TITLE
refactor: import scheduler module

### DIFF
--- a/website/extensions/__init__.py
+++ b/website/extensions/__init__.py
@@ -1,14 +1,5 @@
 from flask_wtf import CSRFProtect
+from .. import scheduler
 
 
 csrf = CSRFProtect()
-
-
-class Scheduler:
-    """Simple placeholder scheduler extension."""
-
-    def init_app(self, app):  # pragma: no cover - placeholder
-        pass
-
-
-scheduler = Scheduler()


### PR DESCRIPTION
## Summary
- replace placeholder scheduler with import of `website.scheduler`
- keep CSRF protection export

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'init_app')*

------
https://chatgpt.com/codex/tasks/task_e_68af44a24af08327b19fee21fda2a28b