### PR TITLE
Rename generator endpoint and streamline job runner

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -54,7 +54,7 @@ def test_generador_stores_and_renders_result():
         lambda *a, **k: ({'metrics': {}}, b'', b'')
     )
     token = _csrf_token(client, '/generador')
-    data = {'excel': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}
+    data = {'archivo': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}
     response = client.post(
         '/generador',
         data=data,

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -6,15 +6,15 @@
     <span class="text-muted small">Replica mejorada del app1 (Streamlit)</span>
   </div>
 
-  <form id="genForm" method="POST" action="{{ url_for('generator.generador_form') }}" enctype="multipart/form-data" class="needs-validation" novalidate>
+  <form id="genForm" method="POST" action="{{ url_for('generator.generador_run') }}" enctype="multipart/form-data" class="needs-validation" novalidate>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Archivo + Perfil -->
     <div class="card mb-4">
       <div class="card-body">
         <div class="row g-3 align-items-end">
           <div class="col-md-6">
-            <label for="excel" class="form-label">Archivo Excel</label>
-            <input type="file" class="form-control" id="excel" name="excel" accept=".xlsx" required>
+            <label for="archivo" class="form-label">Archivo Excel</label>
+            <input type="file" class="form-control" id="archivo" name="archivo" accept=".xlsx" required>
             <div class="invalid-feedback">Sube un archivo .xlsx</div>
           </div>
           <div class="col-md-6">


### PR DESCRIPTION
## Summary
- Rename `generador_form` endpoint to `generador_run` and accept uploaded file from `archivo` field
- Simplify background worker by removing app context requirement and spawning daemon thread
- Update generator template and tests to match new endpoint and file field

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af700fd17483279b054aa3be53fd1c