### PR TITLE
Remove cancelled generator jobs and files

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -3,6 +3,7 @@ import tempfile
 from threading import Thread
 from io import BytesIO
 import importlib
+import os
 
 from flask import (
     Blueprint,
@@ -179,5 +180,13 @@ def cancel_job():
             stopper(thread)
         if isinstance(active, dict):
             active.pop(job_id, None)
-        JOBS[job_id] = {"status": "cancelled"}
+        job_info = JOBS.pop(job_id, None)
+        if job_info:
+            for key in ("excel_path", "csv_path"):
+                path = job_info.get(key) or job_info.get("result", {}).get(key)
+                if path:
+                    try:
+                        os.remove(path)
+                    except Exception:
+                        pass
     return "", 204


### PR DESCRIPTION
## Summary
- Remove cancelled jobs from in-memory job store and scheduler.active_jobs
- Optionally delete any excel_path/csv_path files for cancelled jobs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask==2.3.3 numpy==1.24.3` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_68af7015247483279808c3eafc0b51c0