### PR TITLE
Remove extraneous return in generador redirect

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -65,7 +65,6 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await resp.json();
       if (data.status === 'finished') {
         window.location.href = '/resultados';
-        return;
       }
       if (data.status === 'error') {
         throw new Error('error');


### PR DESCRIPTION
## Summary
- Simplify status polling redirect in `generador.js`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af70172798832799feaa5ee41e2c47