### PR TITLE
Refactor generator upload handler

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -54,7 +54,7 @@ def test_generador_stores_and_renders_result():
         lambda *a, **k: ({'metrics': {}}, b'', b'')
     )
     token = _csrf_token(client, '/generador')
-    data = {'excel': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}
+    data = {'archivo': (BytesIO(b'data'), 'test.xlsx'), 'csrf_token': token}
     response = client.post(
         '/generador',
         data=data,

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -6,15 +6,15 @@
     <span class="text-muted small">Replica mejorada del app1 (Streamlit)</span>
   </div>
 
-  <form id="genForm" method="POST" action="{{ url_for('generator.generador_form') }}" enctype="multipart/form-data" class="needs-validation" novalidate>
+  <form id="genForm" method="POST" action="{{ url_for('generator.generador_run') }}" enctype="multipart/form-data" class="needs-validation" novalidate>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Archivo + Perfil -->
     <div class="card mb-4">
       <div class="card-body">
         <div class="row g-3 align-items-end">
           <div class="col-md-6">
-            <label for="excel" class="form-label">Archivo Excel</label>
-            <input type="file" class="form-control" id="excel" name="excel" accept=".xlsx" required>
+            <label for="archivo" class="form-label">Archivo Excel</label>
+            <input type="file" class="form-control" id="archivo" name="archivo" accept=".xlsx" required>
             <div class="invalid-feedback">Sube un archivo .xlsx</div>
           </div>
           <div class="col-md-6">


### PR DESCRIPTION
## Summary
- rename POST handler to `generador_run`
- accept file via `archivo` field and spawn worker thread
- update templates and tests for new endpoint
- mark cancelled jobs in job store

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af804e8abc832781a5103b16a8daef