### PR TITLE
Improve generator job status handling

### DIFF
--- a/tests/test_generador_status.py
+++ b/tests/test_generador_status.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+from website.generator_routes import JOBS, _worker
+
+app = create_app()
+add_to_allowlist = allowlist_module.add_to_allowlist
+
+
+def _csrf_token(client, path):
+    resp = client.get(path)
+    html = resp.get_data(as_text=True)
+    import re
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    return match.group(1) if match else None
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clear_jobs():
+    JOBS.clear()
+    yield
+    JOBS.clear()
+
+
+def login(client):
+    add_to_allowlist('user@example.com', 'secret')
+    token = _csrf_token(client, '/login')
+    client.post(
+        '/login',
+        data={'email': 'user@example.com', 'password': 'secret', 'csrf_token': token},
+        follow_redirects=True,
+    )
+
+
+def test_worker_failure_stores_error(monkeypatch):
+    def failing_run(*args, **kwargs):
+        raise RuntimeError('boom')
+    from website import generator_routes as gr
+    monkeypatch.setattr(gr, 'scheduler', types.SimpleNamespace(run_complete_optimization=failing_run))
+    job_id = 'jobfail'
+    _worker(app, job_id, b'', {}, False)
+    assert JOBS[job_id] == {'status': 'error', 'error': 'boom'}
+
+
+def test_generador_status_transitions():
+    client = app.test_client()
+    login(client)
+
+    # unknown job
+    response = client.get('/generador/status/nope')
+    assert response.get_json() == {'status': 'unknown'}
+
+    # running job
+    job_id = 'running'
+    JOBS[job_id] = {'status': 'running'}
+    response = client.get(f'/generador/status/{job_id}')
+    assert response.get_json() == {'status': 'running'}
+
+    # finished job
+    job_id = 'done'
+    JOBS[job_id] = {'status': 'finished', 'result': {'x': 1}}
+    response = client.get(f'/generador/status/{job_id}')
+    assert response.get_json() == {'status': 'finished'}
+    with client.session_transaction() as sess:
+        assert sess['resultado'] == {'x': 1}
+
+    # error job
+    job_id = 'fail'
+    JOBS[job_id] = {'status': 'error', 'error': 'oops'}
+    response = client.get(f'/generador/status/{job_id}')
+    assert response.get_json() == {'status': 'error', 'error': 'oops'}

--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -57,8 +57,8 @@ def _worker(app, job_id, excel_bytes, cfg, generate_charts):
                     tmp.write(csv_out)
                 result["csv_url"] = url_for("generator.download", token=token, csv=1)
             JOBS[job_id] = {"status": "finished", "result": result}
-        except Exception:
-            JOBS[job_id] = {"status": "error"}
+        except Exception as e:
+            JOBS[job_id] = {"status": "error", "error": str(e)}
 
 
 @bp.get("/generador")
@@ -127,13 +127,13 @@ def generador_status(job_id):
     if not job:
         return jsonify({"status": "unknown"}), 200
 
-    status = job.get("status")
-    if status == "finished":
-        session["resultado"] = job.get("result")
-        print(f"\u2705 [GENERATOR] Job {job_id} finished")
+    st = job.get("status")
+    if st == "finished":
+        session["resultado"] = job["result"]
+        print(f"[STATUS] job={job_id} -> finished")
         return jsonify({"status": "finished"})
-    if status == "error":
-        print(f"\u274C [GENERATOR] Job {job_id} error: {job.get('error')}")
+    if st == "error":
+        print(f"[STATUS] job={job_id} -> error: {job.get('error')}")
         return jsonify({"status": "error", "error": job.get("error")})
     return jsonify({"status": "running"})
 


### PR DESCRIPTION
## Summary
- capture worker exception details in job store
- persist job result in session and log status transitions
- add tests for worker failure and status responses

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68af804f303c8327a55c47da65d2bd87