### PR TITLE
Track job output paths and clean up on cancel

### DIFF
--- a/tests/test_cancel_route.py
+++ b/tests/test_cancel_route.py
@@ -39,11 +39,21 @@ def login(client):
     )
 
 
-def test_cancel_route_updates_status():
+def test_cancel_route_cleans_up_job(tmp_path):
     client = app.test_client()
     login(client)
     job_id = 'testjob'
-    JOBS[job_id] = {'status': 'running'}
+    excel_path = tmp_path / 'file.xlsx'
+    csv_path = tmp_path / 'file.csv'
+    excel_path.write_text('dummy')
+    csv_path.write_text('dummy')
+    JOBS[job_id] = {
+        'status': 'running',
+        'excel_path': str(excel_path),
+        'csv_path': str(csv_path),
+    }
     response = client.post('/cancel', json={'job_id': job_id})
     assert response.status_code == 204
-    assert JOBS[job_id]['status'] == 'cancelled'
+    assert job_id not in JOBS
+    assert not excel_path.exists()
+    assert not csv_path.exists()


### PR DESCRIPTION
## Summary
- store excel and csv output paths in job metadata
- delete generated files and job data when cancelling
- update cancel route test to assert job removal and file cleanup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_68af8051e2bc83279154acc8e9f88107