### PR TITLE
Log exceptions in generator worker

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -69,6 +69,7 @@ def _worker(app, job_id, file_bytes, config, generate_charts):
                 result["csv_url"] = f"/download/{token}?csv=1"
             scheduler.mark_finished(job_id, result, excel_path, csv_path, app=app)
         except Exception as e:
+            current_app.logger.exception(e)
             scheduler.mark_error(job_id, str(e), app=app)
 
 


### PR DESCRIPTION
## Summary
- Log exceptions from generator worker threads before marking job as error

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_68af9f106ab4832795eb0fbbebdaf87b