### PR TITLE
Mostrar mensaje de error del generador

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -43,10 +43,12 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       const info = await resp.json();
       job_id = info.job_id || job_id;
-      if (!job_id) throw new Error('sin id');
+      if (info.status === 'error' || !job_id) {
+        throw new Error(info.error || 'sin id');
+      }
       pollStatus(job_id);
     } catch (err) {
-      alert('La generación falló. Por favor inténtalo nuevamente.');
+      alert(err.message || 'La generación falló. Por favor inténtalo nuevamente.');
       resetUI();
     }
   });
@@ -65,12 +67,15 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await resp.json();
       if (data.status === 'finished') {
         window.location.href = '/resultados';
+        return;
       }
       if (data.status === 'error') {
-        throw new Error('error');
+        alert(data.error || 'La generación falló. Por favor inténtalo nuevamente.');
+        resetUI();
+        return;
       }
     } catch (err) {
-      alert('La generación falló. Por favor inténtalo nuevamente.');
+      alert(err.message || 'La generación falló. Por favor inténtalo nuevamente.');
       resetUI();
       return;
     }


### PR DESCRIPTION
## Summary
- Muestra el mensaje de error devuelto por el backend durante el sondeo del estado
- Propaga mensajes de error del servidor al iniciar la generación

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9f121e608327a72abb68389e35f5