### PR TITLE
Redirect finished generator jobs to job-specific results

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -138,11 +138,8 @@ def generador_status(job_id):
     st = scheduler.get_status(job_id)
     status = st.get("status")
     if status == "finished":
-        payload = scheduler.get_result(job_id)
-        if payload:
-            session["resultado"] = payload.get("result")
         print(f"\u2705 [GENERATOR] Job {job_id} finished")
-        return jsonify({"status": "finished"})
+        return jsonify({"status": "finished", "redirect": f"/resultados/{job_id}"})
     if status == "error":
         print(f"\u274C [GENERATOR] Job {job_id} error: {st.get('error')}")
         return jsonify({"status": "error", "error": st.get("error")})


### PR DESCRIPTION
## Summary
- Remove session-based result storage in `generador_status`
- Return a redirect URL to `/resultados/<job_id>` when a job finishes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9f1c1a4883278c58a095c57edefa