### PR TITLE
Handle redirect after generator job finishes

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const resp = await fetch(`/generador/status/${job_id}`);
       const data = await resp.json();
       if (data.status === 'finished') {
-        window.location.href = '/resultados';
+        window.location.href = data.redirect || '/resultados';
       }
       if (data.status === 'error') {
         throw new Error('error');


### PR DESCRIPTION
## Summary
- Redirect to job-specified result path in `pollStatus` when generation finishes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af9f1e671883278c89b6a3667ce6a4