### PR TITLE
Refactor result storage to scheduler store

### DIFF
--- a/tests/test_results_cleanup.py
+++ b/tests/test_results_cleanup.py
@@ -2,32 +2,37 @@ import os
 import sys
 import types
 import time
+import importlib
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+STORE = {"results": {}}
+sys.modules['website.scheduler'] = types.SimpleNamespace(_store=lambda app=None: STORE)
 
 from website import create_app
-from website.blueprints import core
+from website.blueprints import core as core_module
+
+core = importlib.reload(core_module)
 
 app = create_app()
 
 
 def test_cleanup_by_age():
     with app.app_context():
-        core._RESULTS.clear()
-        core._RESULTS['old'] = {'timestamp': time.time() - 7200}
-        core._RESULTS['new'] = {'timestamp': time.time()}
+        STORE["results"].clear()
+        STORE["results"]["old"] = {"timestamp": time.time() - 7200}
+        STORE["results"]["new"] = {"timestamp": time.time()}
         core.cleanup_results(max_age=3600)
-        assert 'old' not in core._RESULTS
-        assert 'new' in core._RESULTS
+        assert "old" not in STORE["results"]
+        assert "new" in STORE["results"]
 
 
 def test_cleanup_by_size():
     with app.app_context():
-        core._RESULTS.clear()
+        STORE["results"].clear()
         now = time.time()
         for i in range(5):
-            core._RESULTS[str(i)] = {'timestamp': now + i}
+            STORE["results"][str(i)] = {"timestamp": now + i}
         core.cleanup_results(max_entries=3)
-        assert len(core._RESULTS) == 3
-        assert set(core._RESULTS.keys()) == {'2', '3', '4'}
+        assert len(STORE["results"]) == 3
+        assert set(STORE["results"].keys()) == {"2", "3", "4"}

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -86,6 +86,7 @@ def mark_finished(job_id, result, excel_path, csv_path, app=None):
         "result": result,
         "excel_path": excel_path,
         "csv_path": csv_path,
+        "timestamp": time.time(),
     }
 
 


### PR DESCRIPTION
## Summary
- remove `_RESULTS` global and manage results via `scheduler._store`
- add timestamps to scheduler results and clean old entries
- adjust tests for new result storage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9f1f49dc8327866e91c4d4f85ee6