### PR TITLE
Adapt tests for job-scoped results endpoint

### DIFF
--- a/tests/test_cancel_route.py
+++ b/tests/test_cancel_route.py
@@ -12,6 +12,7 @@ sys.modules['website.scheduler'] = types.SimpleNamespace(
     mark_cancelled=lambda job_id, app=None: _store.update({job_id: {"status": "cancelled"}}),
     get_status=lambda job_id, app=None: _store.get(job_id, {"status": "unknown"}),
     get_result=lambda job_id, app=None: _store.get(job_id),
+    get_payload=lambda job_id, app=None: _store.get(job_id),
     active_jobs={},
 )
 

--- a/tests/test_contacto_route.py
+++ b/tests/test_contacto_route.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(get_payload=lambda *a, **k: None))
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_login_auth.py
+++ b/tests/test_login_auth.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(get_payload=lambda *a, **k: None))
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_navigation_dropdown.py
+++ b/tests/test_navigation_dropdown.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(get_payload=lambda *a, **k: None))
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_register_redirect.py
+++ b/tests/test_register_redirect.py
@@ -3,7 +3,7 @@ import sys
 import types
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(get_payload=lambda *a, **k: None))
 
 from website import create_app
 

--- a/tests/test_results_cleanup.py
+++ b/tests/test_results_cleanup.py
@@ -4,7 +4,7 @@ import types
 import time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(get_payload=lambda *a, **k: None))
 
 from website import create_app
 from website.blueprints import core

--- a/tests/test_subscribe_route.py
+++ b/tests/test_subscribe_route.py
@@ -7,7 +7,7 @@ import pytest
 from flask import template_rendered
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(get_payload=lambda *a, **k: None))
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/tests/test_subscribe_success_route.py
+++ b/tests/test_subscribe_success_route.py
@@ -7,7 +7,7 @@ import pytest
 from flask import template_rendered
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace(get_payload=lambda *a, **k: None))
 
 from website import create_app
 from website.utils import allowlist as allowlist_module

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -64,7 +64,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const resp = await fetch(`/generador/status/${job_id}`);
       const data = await resp.json();
       if (data.status === 'finished') {
-        window.location.href = '/resultados';
+        const url = data.redirect || `/resultados/${job_id}`;
+        window.location.href = url;
       }
       if (data.status === 'error') {
         throw new Error('error');

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -33,7 +33,9 @@
         <div class="collapse navbar-collapse" id="navMain">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item"><a href="{{ url_for('generator.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generator.generador' else '' }}">Generador</a></li>
-            <li class="nav-item"><a href="{{ url_for('generator.resultados') }}" class="nav-link {{ 'active' if request.endpoint=='generator.resultados' else '' }}">Resultados</a></li>
+            {% if session.get('last_job_id') %}
+            <li class="nav-item"><a href="{{ url_for('generator.resultados', job_id=session.get('last_job_id')) }}" class="nav-link {{ 'active' if request.endpoint=='generator.resultados' else '' }}">Resultados</a></li>
+            {% endif %}
             <li class="nav-item"><a href="{{ url_for('core.configuracion') }}" class="nav-link {{ 'active' if request.endpoint=='configuracion' else '' }}">Configuración</a></li>
           </ul>
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">


### PR DESCRIPTION
## Summary
- Update generator routes to serve results by job ID and include redirect in status responses
- Revise frontend and navigation to handle job-based results URLs
- Adjust tests and scheduler mocks to use new `get_payload` interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9f2071fc8327b2fce5c2598f84a7