### PR TITLE
Refactor resultados route to fetch scheduler payloads by job id

### DIFF
--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -28,6 +28,7 @@ sys.modules['website.scheduler'] = types.SimpleNamespace(
     mark_cancelled=lambda job_id, app=None: STORE["jobs"].update({job_id: {"status": "cancelled"}}),
     get_status=lambda job_id, app=None: STORE["jobs"].get(job_id, {"status": "unknown"}),
     get_result=lambda job_id, app=None: STORE["results"].get(job_id),
+    get_payload=lambda job_id, app=None: STORE["results"].get(job_id),
     run_complete_optimization=lambda *a, **k: ({}, b"", b""),
     active_jobs={},
     _store=lambda app=None: STORE,
@@ -71,12 +72,12 @@ def login(client):
     )
 
 
-def test_resultados_without_result_shows_message():
+def test_resultados_without_result_returns_500():
     client = app.test_client()
     login(client)
-    response = client.get('/resultados')
-    assert response.status_code == 200
-    assert b'No hay resultados' in response.data
+    response = client.get('/resultados/unknown')
+    assert response.status_code == 500
+    assert b'Resultado no disponible' in response.data
 
 
 def test_generador_stores_and_renders_result():
@@ -101,6 +102,6 @@ def test_generador_stores_and_renders_result():
         if status == 'finished':
             break
         time.sleep(0.1)
-    result_page = client.get('/resultados')
+    result_page = client.get(f'/resultados/{job_id}')
     assert result_page.status_code == 200
     assert b'Resultados' in result_page.data

--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -11,7 +11,6 @@ from flask import (
     Blueprint,
     render_template,
     request,
-    session,
     jsonify,
     send_file,
     abort,
@@ -147,11 +146,13 @@ def generador_status(job_id):
     return jsonify({"status": status or "unknown"})
 
 
-@bp.get("/resultados")
+@bp.get("/resultados/<job_id>")
 @login_required
-def resultados():
-    resultado = session.get("resultado")
-    return render_template("resultados.html", resultado=resultado)
+def resultados(job_id):
+    payload = scheduler.get_payload(job_id)
+    if not payload:
+        return render_template("500.html", message="Resultado no disponible"), 500
+    return render_template("resultados.html", resultado=payload["result"])
 
 
 @bp.get("/download/<token>")

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -108,6 +108,10 @@ def get_result(job_id, app=None):
     return _store(app).get("results", {}).get(job_id)
 
 
+# Compatibility alias
+get_payload = get_result
+
+
 def _stop_thread(thread):
     """Attempt to stop a running thread by raising ``SystemExit`` inside it."""
     if thread and thread.is_alive():  # pragma: no cover - safety guard

--- a/website/templates/500.html
+++ b/website/templates/500.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
   <h1>Error interno del servidor</h1>
-  <p>Ha ocurrido un error inesperado.</p>
-  <a href="{{ url_for('landing') }}" class="btn btn-primary mt-3">Volver al inicio</a>
+  <p>{{ message or 'Ha ocurrido un error inesperado.' }}</p>
+  <a href="{{ url_for('core.landing') }}" class="btn btn-primary mt-3">Volver al inicio</a>
 {% endblock %}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -33,7 +33,14 @@
         <div class="collapse navbar-collapse" id="navMain">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item"><a href="{{ url_for('generator.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generator.generador' else '' }}">Generador</a></li>
-            <li class="nav-item"><a href="{{ url_for('generator.resultados') }}" class="nav-link {{ 'active' if request.endpoint=='generator.resultados' else '' }}">Resultados</a></li>
+            {% set job_id = request.view_args.get('job_id') if request.view_args else None %}
+            <li class="nav-item">
+              {% if job_id %}
+              <a href="{{ url_for('generator.resultados', job_id=job_id) }}" class="nav-link {{ 'active' if request.endpoint=='generator.resultados' else '' }}">Resultados</a>
+              {% else %}
+              <span class="nav-link disabled">Resultados</span>
+              {% endif %}
+            </li>
             <li class="nav-item"><a href="{{ url_for('core.configuracion') }}" class="nav-link {{ 'active' if request.endpoint=='configuracion' else '' }}">Configuración</a></li>
           </ul>
           <button class="btn btn-outline-secondary me-3" id="themeToggle" aria-label="Cambiar tema" type="button">


### PR DESCRIPTION
## Summary
- Require a job id for the resultados route and retrieve payloads via scheduler
- Alias `scheduler.get_payload` to `get_result`
- Handle missing payloads with a 500 page and expose messages
- Update navigation and error templates for job-aware links
- Adjust tests for the new resultados behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa3764d48832785199ceb9d49b347