### PR TITLE
Allow custom redirect after generator completion

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const resp = await fetch(`/generador/status/${job_id}`);
       const data = await resp.json();
       if (data.status === 'finished') {
-        window.location.href = '/resultados';
+        window.location.href = data.redirect || '/resultados';
         return;
       }
       if (data.status === 'error') {


### PR DESCRIPTION
## Summary
- allow `pollStatus` to use server-provided redirect

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_68afa376b50c832793a4dca438e63969