### PR TITLE
Show custom server error message

### DIFF
--- a/website/templates/500.html
+++ b/website/templates/500.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
   <h1>Error interno del servidor</h1>
-  <p>Ha ocurrido un error inesperado.</p>
+  <p>{{ message or 'Ha ocurrido un error inesperado.' }}</p>
   <a href="{{ url_for('landing') }}" class="btn btn-primary mt-3">Volver al inicio</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show provided message on 500 error page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68afa378a2ac8327ac59830a0fbd61f4