### PR TITLE
test: adjust resultados route to job id

### DIFF
--- a/tests/test_cancel_route.py
+++ b/tests/test_cancel_route.py
@@ -12,6 +12,7 @@ sys.modules['website.scheduler'] = types.SimpleNamespace(
     mark_cancelled=lambda job_id, app=None: _store.update({job_id: {"status": "cancelled"}}),
     get_status=lambda job_id, app=None: _store.get(job_id, {"status": "unknown"}),
     get_result=lambda job_id, app=None: _store.get(job_id),
+    get_payload=lambda job_id, app=None: _store.get(job_id),
     active_jobs={},
 )
 


### PR DESCRIPTION
## Summary
- expect `/resultados/<job_id>` and generator status redirects in tests
- add `get_payload` mock in tests relying on scheduler

## Testing
- `pytest`
- `pytest tests/test_resultados_route.py` *(fails: assert 404 == 500)*

------
https://chatgpt.com/codex/tasks/task_e_68afa379515c8327b31ccd7f6e51880c