### PR TITLE
Add get_payload wrapper for scheduler results

### DIFF
--- a/tests/test_cancel_route.py
+++ b/tests/test_cancel_route.py
@@ -12,6 +12,7 @@ sys.modules['website.scheduler'] = types.SimpleNamespace(
     mark_cancelled=lambda job_id, app=None: _store.update({job_id: {"status": "cancelled"}}),
     get_status=lambda job_id, app=None: _store.get(job_id, {"status": "unknown"}),
     get_result=lambda job_id, app=None: _store.get(job_id),
+    get_payload=lambda job_id, app=None: _store.get(job_id),
     active_jobs={},
 )
 

--- a/tests/test_resultados_route.py
+++ b/tests/test_resultados_route.py
@@ -28,6 +28,7 @@ sys.modules['website.scheduler'] = types.SimpleNamespace(
     mark_cancelled=lambda job_id, app=None: STORE["jobs"].update({job_id: {"status": "cancelled"}}),
     get_status=lambda job_id, app=None: STORE["jobs"].get(job_id, {"status": "unknown"}),
     get_result=lambda job_id, app=None: STORE["results"].get(job_id),
+    get_payload=lambda job_id, app=None: STORE["results"].get(job_id),
     run_complete_optimization=lambda *a, **k: ({}, b"", b""),
     active_jobs={},
     _store=lambda app=None: STORE,

--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -189,7 +189,7 @@ def cancel_job():
         if isinstance(active, dict):
             active.pop(job_id, None)
         scheduler.mark_cancelled(job_id)
-        payload = scheduler.get_result(job_id)
+        payload = scheduler.get_payload(job_id)
         if payload:
             for key in ("excel_path", "csv_path"):
                 path = payload.get(key)

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -108,6 +108,10 @@ def get_result(job_id, app=None):
     return _store(app).get("results", {}).get(job_id)
 
 
+def get_payload(job_id, app=None):
+    return get_result(job_id, app)
+
+
 def _stop_thread(thread):
     """Attempt to stop a running thread by raising ``SystemExit`` inside it."""
     if thread and thread.is_alive():  # pragma: no cover - safety guard


### PR DESCRIPTION
## Summary
- add `get_payload` to scheduler to wrap `get_result`
- use `get_payload` in generator cancel route
- update tests with `get_payload` stubs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa377923883278a71776d73f1677d