### PR TITLE
Validate download token path

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -158,6 +158,8 @@ def resultados(job_id):
 @bp.get("/download/<token>")
 @login_required
 def download(token):
+    if os.path.basename(token) != token:
+        abort(404)
     path = os.path.join(tempfile.gettempdir(), token)
     if not os.path.exists(path):
         abort(404)


### PR DESCRIPTION
## Summary
- ensure download token does not contain path separators

## Testing
- `pytest` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68afa9002b148327b3e9cb9d9cc65685