### PR TITLE
Robust cancel parsing and beacon blob

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -180,6 +180,11 @@ def download(token):
 @csrf.exempt
 def cancel_job():
     data = request.get_json(silent=True) or {}
+    if not data:
+        try:
+            data = json.loads(request.get_data(as_text=True))
+        except Exception:
+            data = {}
     job_id = data.get("job_id")
     if job_id:
         active = getattr(scheduler, "active_jobs", {}) or {}

--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -56,7 +56,10 @@ document.addEventListener('DOMContentLoaded', () => {
   window.addEventListener('pagehide', () => {
     if (controller) {
       controller.abort();
-      navigator.sendBeacon('/cancel', JSON.stringify({ job_id }));
+      navigator.sendBeacon(
+        '/cancel',
+        new Blob([JSON.stringify({ job_id })], { type: 'application/json' })
+      );
       resetUI();
     }
   });


### PR DESCRIPTION
## Summary
- Use `navigator.sendBeacon` with a Blob to send JSON job ID when page hides
- Add fallback parsing of raw request body in `/cancel` route if `get_json` returns empty

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*


------
https://chatgpt.com/codex/tasks/task_e_68afa901ffdc83279e81a44aedf6896d