### PR TITLE
Register background job threads

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -123,11 +123,13 @@ def generador_form():
     scheduler.mark_running(job_id)
 
     app_obj = current_app._get_current_object()
-    threading.Thread(
+    thread = threading.Thread(
         target=_worker,
         args=(app_obj, job_id, excel_bytes, cfg, generate_charts),
         daemon=True,
-    ).start()
+    )
+    scheduler.active_jobs[job_id] = thread
+    thread.start()
 
     return jsonify({"job_id": job_id}), 202
 


### PR DESCRIPTION
## Summary
- Create generator worker thread without starting immediately
- Register each thread in `scheduler.active_jobs` before starting

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68afa900f8f08327975ed551fb93348d