### PR TITLE
Use job-aware fallback URL in pollStatus

### DIFF
--- a/website/static/js/generador.js
+++ b/website/static/js/generador.js
@@ -69,7 +69,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const resp = await fetch(`/generador/status/${job_id}`);
       const data = await resp.json();
       if (data.status === 'finished') {
-        window.location.href = data.redirect || '/resultados';
+        const url = data.redirect || `/resultados/${job_id}`;
+        window.location.href = url;
         return;
       }
       if (data.status === 'error') {


### PR DESCRIPTION
## Summary
- Redirect finished jobs to job-specific resultados page if no redirect provided

## Testing
- `npx eslint website/static/js/generador.js` *(fails: ESLint couldn't find a configuration file)*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*


------
https://chatgpt.com/codex/tasks/task_e_68afaed582dc8327838ccf43ce3fe4c9