### PR TITLE
Handle missing resultados ID with 400 error

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -148,6 +148,14 @@ def generador_status(job_id):
     return jsonify({"status": status or "unknown"})
 
 
+@bp.get("/resultados")
+@login_required
+def resultados_missing():
+    return render_template(
+        "400.html", description="Faltó el ID del resultado"
+    ), 400
+
+
 @bp.get("/resultados/<job_id>")
 @login_required
 def resultados(job_id):


### PR DESCRIPTION
## Summary
- add /resultados route returning a 400 when no job ID is provided

## Testing
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68afaed68d2083278c2075afbeca7630