### PR TITLE
Handle POST requests at root landing page

### DIFF
--- a/tests/test_landing_post.py
+++ b/tests/test_landing_post.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('website.scheduler', types.SimpleNamespace())
+
+from website import create_app
+from website.utils import allowlist as allowlist_module
+
+app = create_app()
+
+
+@pytest.fixture(autouse=True)
+def temp_allowlist(tmp_path):
+    allowlist_module.ALLOWLIST_FILE = tmp_path / "allowlist.json"
+    yield
+
+
+def test_post_root_redirects_to_landing():
+    client = app.test_client()
+    response = client.post('/', follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/')

--- a/website/blueprints/core.py
+++ b/website/blueprints/core.py
@@ -132,6 +132,17 @@ def landing():
     # o: return redirect(url_for("core.login"))
 
 
+@bp.post("/")
+@csrf.exempt
+def landing_post():
+    """Handle stray POST requests to the landing page.
+
+    Some automated clients may POST to ``/`` which previously resulted in a
+    405 error being logged. Redirect them back to the landing page instead.
+    """
+    return redirect(url_for("core.landing"))
+
+
 @bp.route("/index")
 def index():
     return render_template("index.html")


### PR DESCRIPTION
## Summary
- Redirect POST `/` requests to the landing page to avoid 405 log spam
- Add regression test ensuring POST `/` returns a redirect

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afb2ab41488327936d9dd969eecc28