### PR TITLE
Refactor scheduler store and job cleanup

### DIFF
--- a/website/extensions.py
+++ b/website/extensions.py
@@ -11,12 +11,16 @@ class SchedulerStore:
             app.extensions["scheduler"] = {
                 "jobs": {},      # job_id -> {"status": "running|finished|error|cancelled", ...}
                 "results": {},   # job_id -> {"result": {...}, "excel_path": "...", "csv_path": "..."}
-                "active": {}     # job_id -> thread (opcional)
+                "active_jobs": {}     # job_id -> thread (opcional)
             }
 
     def _s(self, app=None):
         app = app or current_app
-        return app.extensions["scheduler"]
+        if not hasattr(app, "extensions"):
+            app.extensions = {}
+        return app.extensions.setdefault(
+            "scheduler", {"jobs": {}, "results": {}, "active_jobs": {}}
+        )
 
     # --- API usada por tus rutas/worker ---
     def mark_running(self, job_id, app=None):
@@ -67,6 +71,6 @@ class SchedulerStore:
 
     @property
     def active_jobs(self):
-        return self._s().setdefault("active", {})
+        return self._s().setdefault("active_jobs", {})
 
 scheduler = SchedulerStore()

--- a/website/extensions/__init__.py
+++ b/website/extensions/__init__.py
@@ -8,15 +8,38 @@ class SchedulerStore:
         if not hasattr(app, "extensions"):
             app.extensions = {}
         if "scheduler" not in app.extensions:
-            app.extensions["scheduler"] = {"jobs": {}, "results": {}, "active": {}}
+            app.extensions["scheduler"] = {
+                "jobs": {},
+                "results": {},
+                "active_jobs": {},
+            }
 
     def _s(self, app=None):
         app = app or current_app
-        return app.extensions["scheduler"]
+        if not hasattr(app, "extensions"):
+            app.extensions = {}
+        return app.extensions.setdefault(
+            "scheduler", {"jobs": {}, "results": {}, "active_jobs": {}}
+        )
 
     def mark_running(self, job_id, app=None):
         s = self._s(app)
-        s["jobs"][job_id] = {"status": "running"}
+        s["jobs"][job_id] = {"status": "running", "progress": {}}
+
+    def update_progress(self, job_id, info, app=None):
+        """Merge progress ``info`` into ``jobs[job_id]['progress']`` without
+        altering the job status."""
+        s = self._s(app)
+        jobs = s.setdefault("jobs", {})
+        job = jobs.setdefault(job_id, {"status": "running"})
+        progress = job.get("progress", {})
+        if not isinstance(progress, dict):
+            progress = {}
+        if not isinstance(info, dict):
+            info = {"msg": str(info)}
+        progress.update(info)
+        job["progress"] = progress
+        jobs[job_id] = job
 
     def mark_finished(self, job_id, result_dict, excel_path, csv_path, app=None):
         s = self._s(app)
@@ -46,6 +69,6 @@ class SchedulerStore:
 
     @property
     def active_jobs(self):
-        return self._s().setdefault("active", {})
+        return self._s().setdefault("active_jobs", {})
 
 scheduler = SchedulerStore()


### PR DESCRIPTION
## Summary
- track threads under `active_jobs` with new progress updater
- clean up completed or cancelled jobs using `_stop_thread`
- align modules with `active_jobs` key

## Testing
- `pytest tests/test_cancel_route.py::test_cancel_route_updates_status tests/test_resultados_route.py::test_generador_stores_and_renders_result -q`
- `pytest -q` *(fails: `Dummy() takes no arguments`, `assert 'unknown' == 'cancelled'`, missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e4489fc88327bc0bfb1e5853ba96