### PR TITLE
Improve partial PuLP snapshots with charts and frontend rendering

### DIFF
--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -49,3 +49,48 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+// ------------------- PuLP Charts -------------------
+let _covChart, _defChart, _excChart;
+
+function renderMatrixChart(canvasId, labels, matrix, title) {
+  const ctx = document.getElementById(canvasId);
+  const days = labels.days || [];
+  const hours = labels.hours || [];
+  const datasets = (matrix || []).map((row, i) => ({
+    label: days[i] ?? `Día ${i+1}`,
+    data: row,
+  }));
+  return new Chart(ctx, {
+    type: 'line',
+    data: { labels: hours, datasets },
+    options: { responsive: true, plugins: { title: { display: true, text: title } } }
+  });
+}
+
+function updatePulpCharts(pr) {
+  if (!pr || !pr.charts) return;
+
+  const { labels, demand, coverage, deficit, excess } = pr.charts;
+
+  if (_covChart) _covChart.destroy();
+  if (_defChart) _defChart.destroy();
+  if (_excChart) _excChart.destroy();
+
+  _covChart = renderMatrixChart('chartCoverage', labels, coverage, 'Cobertura');
+  _defChart = renderMatrixChart('chartDeficit', labels, deficit, 'Déficit');
+  _excChart = renderMatrixChart('chartExcess', labels, excess, 'Exceso');
+}
+
+function onRefreshPayload(payload) {
+  if (!payload) return;
+  if (payload.pulp_results) {
+    updatePulpCharts(payload.pulp_results);
+
+    const m = payload.pulp_results.metrics;
+    if (m && typeof m.coverage_percentage === 'number') {
+      const el = document.getElementById('pulp-coverage-pct');
+      if (el) el.textContent = `${m.coverage_percentage}%`;
+    }
+  }
+}
+

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -145,7 +145,7 @@
             </div>
             <div class="col-4">
               <div class="small text-muted">Cobertura</div>
-              <div class="fw-bold">
+              <div class="fw-bold" id="pulp-coverage-pct">
                 {% if resultado.pulp_results.metrics.coverage_percentage is not none %}
                   {{ '%.1f'|format(resultado.pulp_results.metrics.coverage_percentage) }}%
                 {% else %}
@@ -216,7 +216,23 @@
     </div>
     {% endif %}
   </div>
-  {% endif %}
+{% endif %}
+
+  <!-- Gráficas PuLP dinámicas -->
+  <div class="row g-4 mb-4">
+    <div class="col-12">
+      <div id="pulp-charts" class="card">
+        <div class="card-body">
+          <h5 class="card-title">Cobertura vs. Demanda (PuLP)</h5>
+          <canvas id="chartCoverage"></canvas>
+          <h6 class="mt-4">Déficit</h6>
+          <canvas id="chartDeficit"></canvas>
+          <h6 class="mt-4">Exceso</h6>
+          <canvas id="chartExcess"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <!-- Resultado Principal -->
   {% if resultado and resultado.pulp_results and resultado.pulp_results.metrics %}
@@ -572,6 +588,8 @@
   <div class="alert alert-warning">No hay resultados para mostrar.</div>
   {% endif %}
 
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+
 <script>
 // Progreso en tiempo real y auto-refresh
   if (window.location.pathname.includes('/resultados/')) {
@@ -585,6 +603,9 @@
       try {
         const response = await fetch(`/resultados/${jobId}/refresh`);
         const data = await response.json();
+        if (typeof onRefreshPayload === 'function') {
+          onRefreshPayload(data);
+        }
 
         // Actualizar progreso PuLP
       if (data.pulp_progress) {


### PR DESCRIPTION
## Summary
- add rich `_write_partial_result` that computes coverage/deficit/excess charts and avoids overwriting better assignments
- render PuLP coverage, deficit, and excess charts on results page using Chart.js and expose coverage percent for live updates
- configure PuLP CBC solver with logging and error capture for partial results

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b79e25b03c832783eb476fd35d7ded