### PR TITLE
Improve partial PuLP snapshots with charts and frontend rendering

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -1961,10 +1961,9 @@ def optimize_jean_search(
                 _write_partial_result(
                     job_id,
                     None,
-                    shifts_coverage,
-                    demand_matrix,
-                    iteration=iteration + 1,
-                    factor=factor,
+                    None,
+                    None,
+                    meta={"iteration": iteration + 1, "factor": factor},
                 )
         except Exception:
             pass
@@ -1986,13 +1985,18 @@ def optimize_jean_search(
         # Publicar snapshot parcial de esta iteración para que la UI siempre muestre progreso
         try:
             if job_id is not None:
+                try:
+                    D, H = demand_matrix.shape
+                except Exception:
+                    D = len(demand_matrix)
+                    H = len(demand_matrix[0]) if D else 0
+                pat_small = _compact_patterns_for(assignments or {}, shifts_coverage, D, H)
                 _write_partial_result(
                     job_id,
                     assignments or {},
-                    shifts_coverage,
+                    pat_small,
                     demand_matrix,
-                    iteration=iteration + 1,
-                    factor=factor,
+                    meta={"iteration": iteration + 1, "factor": factor},
                 )
                 update_progress(
                     job_id,
@@ -2209,12 +2213,43 @@ def analyze_results(assignments, shifts_coverage, demand_matrix):
         'understaffing': understaffing,
         'diff_matrix': diff_matrix
     }
-def _safe_sum(d):
-    return sum(d.values()) if isinstance(d, dict) else 0
 
 
-def _write_partial_result(job_id, assignments, patterns, demand_matrix, **meta):
+def _compact_patterns_for(assignments, patterns, D, H):
+    """Devuelve solo los patrones usados normalizados a matriz D×H."""
+    used = set()
+    for v in assignments.values():
+        pid = v.get("pattern") if isinstance(v, dict) else v
+        used.add(pid)
+    small = {}
+    for pid in used:
+        p = patterns.get(pid)
+        if p is None:
+            continue
+        mat = p.get("matrix", p)
+        arr = np.asarray(mat, dtype=int).reshape(D, H).tolist()
+        small[pid] = {"matrix": arr}
+    return small
+
+
+def _write_partial_result(job_id, assignments, patterns, demand_matrix, *, meta=None):
+    """
+    Graba un snapshot ligero en: %TEMP%/scheduler_result_{job_id}.json
+
+    - No sobreescribe assignments válidos con None.
+    - Calcula y persiste 'charts' (demand, coverage, deficit, excess) si tiene
+      assignments + patterns + demand_matrix.
+    """
+    import os, json, time, tempfile
+    from collections import defaultdict
+    try:
+        import numpy as np
+    except Exception:
+        np = None  # evitamos fallo por import
+
     path = os.path.join(tempfile.gettempdir(), f"scheduler_result_{job_id}.json")
+
+    # lee previo
     try:
         with open(path, "r", encoding="utf-8") as fh:
             existing = json.load(fh)
@@ -2222,38 +2257,141 @@ def _write_partial_result(job_id, assignments, patterns, demand_matrix, **meta):
         existing = {}
 
     pr = existing.setdefault("pulp_results", {})
+    meta = (meta or {})
 
-    # >>>>> PARCHE: NO tocar assignments si assignments es None
+    # ---------- anti-borrado ----------
+    wrote_new = False
     if assignments is None:
-        new_cnt = None
-        prev_cnt = _safe_sum(pr.get("assignments", {}))
-        wrote_new = False
+        # no tocar assignments previos
+        pass
     else:
-        new_cnt = _safe_sum(assignments)
-        prev_cnt = _safe_sum(pr.get("assignments", {}))
-        # Solo aceptar reemplazo si el nuevo tiene contenido (>0) o si nunca hubo nada
-        if new_cnt > 0 or prev_cnt == 0:
+        # contamos "cuánto" nuevo hay. Soportamos dos formas:
+        # a) assignments = {agente: patron}
+        # b) assignments = {patron: cantidad}
+        def _safe_sum(d):
+            try:
+                return sum(int(v) for v in d.values())
+            except Exception:
+                return 0
+
+        prev_cnt = int(pr.get("assignments_count", 0))
+        # intentamos deducir el tipo
+        new_cnt = 0
+        try:
+            vals = list(assignments.values())
+            if vals and isinstance(vals[0], (str, int, tuple, dict)):
+                # tipo a) probablemente {agente: patron} o similar
+                new_cnt = len(assignments)
+            else:
+                new_cnt = _safe_sum(assignments)
+        except Exception:
+            new_cnt = _safe_sum(assignments)
+
+        # solo aceptamos algo si trae contenido y no es "menos" que lo previo
+        if new_cnt > 0 and new_cnt >= prev_cnt:
             pr["assignments"] = assignments
+            pr["assignments_count"] = int(new_cnt)
+            pr["status"] = "PARTIAL"
             wrote_new = True
-        else:
-            wrote_new = False
-    # <<<<< FIN PARCHE
 
-    # Actualiza meta sin campos pesados
-    pr.update({k: v for k, v in meta.items() if k not in ("patterns", "demand_matrix")})
+    # ---------- métricas y charts ligeros ----------
+    # Si tenemos todo, computamos series; si falta algo, dejamos lo previo.
+    if np is not None and demand_matrix is not None and patterns is not None and pr.get("assignments"):
+        try:
+            dm = np.array(demand_matrix, dtype=int)
+            if dm.ndim != 2:
+                raise ValueError("demand_matrix debe ser 2D [dias x horas]")
+            D, H = dm.shape
+            cov = np.zeros_like(dm, dtype=int)
+
+            # normaliza patterns -> devuelve matriz [D,H] para cada patrón
+            def pat_matrix(p):
+                if isinstance(p, dict):
+                    for k in ("matrix", "mat", "cover", "grid", "m"):
+                        if k in p:
+                            arr = np.array(p[k], dtype=int)
+                            break
+                    else:
+                        # si viniera plano, tratamos de reshapar
+                        arr = np.array(list(p.values())[0], dtype=int)
+                else:
+                    arr = np.array(p, dtype=int)
+                if arr.ndim == 1:
+                    arr = arr.reshape(D, H)
+                return arr
+
+            # map de patrón -> cantidad
+            counts = defaultdict(int)
+            sample = next(iter(pr["assignments"].values()))
+            # caso {agente: patron}
+            if isinstance(sample, (str, int, tuple)) or (isinstance(sample, dict) and "pattern" in sample):
+                for v in pr["assignments"].values():
+                    pat_id = v["pattern"] if isinstance(v, dict) else v
+                    counts[pat_id] += 1
+            else:
+                # caso {patron: cantidad}
+                for pat_id, c in pr["assignments"].items():
+                    try:
+                        counts[pat_id] += int(c)
+                    except Exception:
+                        pass
+
+            for pat_id, c in counts.items():
+                p_raw = patterns.get(pat_id)
+                if p_raw is None:
+                    continue
+                cov += int(c) * pat_matrix(p_raw)
+
+            deficit = np.maximum(dm - cov, 0)
+            excess  = np.maximum(cov - dm, 0)
+            served  = np.minimum(cov, dm)
+
+            required = int(dm.sum())
+            covered  = int(served.sum())
+            under    = int(deficit.sum())
+            over     = int(excess.sum())
+
+            pr["metrics"] = {
+                "coverage_percentage": round(100.0 * covered / required, 1) if required else 100.0,
+                "understaffing": under,
+                "overstaffing": over,
+            }
+
+            # etiquetas simples si no vienen en meta
+            day_labels   = meta.get("day_labels") or [f"Día {i+1}" for i in range(D)]
+            hour_labels  = meta.get("hour_labels") or list(range(H))
+
+            pr["charts"] = {
+                "labels": {"days": day_labels, "hours": hour_labels},
+                "demand": dm.tolist(),
+                "coverage": cov.tolist(),
+                "deficit": deficit.tolist(),
+                "excess": excess.tolist(),
+            }
+        except Exception as e:
+            # no rompemos: dejamos parciales previos
+            pr.setdefault("errors", []).append(f"charts_failed: {type(e).__name__}: {e}")
+
+    # meta liviana (sin campos pesados)
+    if meta:
+        for k, v in meta.items():
+            if k not in ("patterns", "demand_matrix"):
+                pr[k] = v
+
+    # persistimos
     existing["pulp_results"] = pr
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(existing, fh, ensure_ascii=False)
+            fh.flush(); os.fsync(fh.fileno())
+    except Exception:
+        pass
 
-    with open(path, "w", encoding="utf-8") as fh:
-        json.dump(existing, fh, ensure_ascii=False)
-        fh.flush()
-        os.fsync(fh.fileno())
-
-    # Log claro para verificar el comportamiento
-    print(
-        f"[PARTIAL] {path} escrito (PuLP) — "
-        f"new={new_cnt if new_cnt is not None else 'None'}, "
-        f"prev={prev_cnt}, wrote_new={wrote_new}"
-    )
+    # log corto opcional
+    try:
+        print(f"[PARTIAL] {path} escrito (PuLP) — assignments={pr.get('assignments_count', 0)}, wrote_new={wrote_new}")
+    except Exception:
+        pass
 
 
 def create_heatmap(matrix, title, cmap='RdYlBu_r'):
@@ -2957,7 +3095,13 @@ def run_complete_optimization(file_stream, config=None, generate_charts=False, j
             )
             if job_id:
                 try:
-                    _write_partial_result(job_id, assignments, patterns, demand_matrix)
+                    try:
+                        D, H = demand_matrix.shape
+                    except Exception:
+                        D = len(demand_matrix)
+                        H = len(demand_matrix[0]) if D else 0
+                    pat_small = _compact_patterns_for(assignments, patterns, D, H)
+                    _write_partial_result(job_id, assignments, pat_small, demand_matrix)
                 except Exception:
                     pass
             results = analyze_results(assignments, patterns, demand_matrix)
@@ -3059,7 +3203,13 @@ def run_complete_optimization(file_stream, config=None, generate_charts=False, j
         # Guardar snapshot parcial para que la UI pueda refrescar
         if job_id:
             try:
-                _write_partial_result(job_id, assignments, patterns, demand_matrix)
+                try:
+                    D, H = demand_matrix.shape
+                except Exception:
+                    D = len(demand_matrix)
+                    H = len(demand_matrix[0]) if D else 0
+                pat_small = _compact_patterns_for(assignments, patterns, D, H)
+                _write_partial_result(job_id, assignments, pat_small, demand_matrix)
             except Exception:
                 pass
 

--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -49,3 +49,47 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+// ------------------- PuLP Charts -------------------
+let _covChart, _defChart, _excChart;
+
+function renderMatrixChart(canvasId, labels, matrix, title) {
+  const ctx = document.getElementById(canvasId);
+  const days = labels.days || [];
+  const hours = labels.hours || [];
+  const datasets = (matrix || []).map((row, i) => ({
+    label: days[i] ?? `Día ${i+1}`,
+    data: row,
+  }));
+  return new Chart(ctx, {
+    type: 'line',
+    data: { labels: hours, datasets },
+    options: { responsive: true, plugins: { title: { display: true, text: title } } }
+  });
+}
+
+function updatePulpCharts(pr) {
+  if (!pr || !pr.charts) return;
+
+  const { labels, demand, coverage, deficit, excess } = pr.charts;
+
+  if (_covChart) _covChart.destroy();
+  if (_defChart) _defChart.destroy();
+  if (_excChart) _excChart.destroy();
+
+  _covChart = renderMatrixChart('chartCoverage', labels, coverage, 'Cobertura');
+  _defChart = renderMatrixChart('chartDeficit', labels, deficit, 'Déficit');
+  _excChart = renderMatrixChart('chartExcess', labels, excess, 'Exceso');
+}
+
+function onRefreshPayload(payload) {
+  if (!payload) return;
+  if (payload.pulp_results && payload.pulp_results.charts) {
+    updatePulpCharts(payload.pulp_results);
+  }
+  const m = payload.pulp_results && payload.pulp_results.metrics;
+  if (m && typeof m.coverage_percentage === 'number') {
+    const el = document.getElementById('pulp-coverage-pct');
+    if (el) el.textContent = `${m.coverage_percentage}%`;
+  }
+}
+

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -145,7 +145,7 @@
             </div>
             <div class="col-4">
               <div class="small text-muted">Cobertura</div>
-              <div class="fw-bold">
+              <div class="fw-bold" id="pulp-coverage-pct">
                 {% if resultado.pulp_results.metrics.coverage_percentage is not none %}
                   {{ '%.1f'|format(resultado.pulp_results.metrics.coverage_percentage) }}%
                 {% else %}
@@ -216,7 +216,23 @@
     </div>
     {% endif %}
   </div>
-  {% endif %}
+{% endif %}
+
+  <!-- Gráficas PuLP dinámicas -->
+  <div class="row g-4 mb-4">
+    <div class="col-12">
+      <div id="pulp-charts" class="card">
+        <div class="card-body">
+          <h5 class="card-title">Cobertura vs. Demanda (PuLP)</h5>
+          <canvas id="chartCoverage"></canvas>
+          <h6 class="mt-4">Déficit</h6>
+          <canvas id="chartDeficit"></canvas>
+          <h6 class="mt-4">Exceso</h6>
+          <canvas id="chartExcess"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <!-- Resultado Principal -->
   {% if resultado and resultado.pulp_results and resultado.pulp_results.metrics %}
@@ -572,6 +588,8 @@
   <div class="alert alert-warning">No hay resultados para mostrar.</div>
   {% endif %}
 
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+
 <script>
 // Progreso en tiempo real y auto-refresh
   if (window.location.pathname.includes('/resultados/')) {
@@ -585,6 +603,9 @@
       try {
         const response = await fetch(`/resultados/${jobId}/refresh`);
         const data = await response.json();
+        if (typeof onRefreshPayload === 'function') {
+          onRefreshPayload(data);
+        }
 
         // Actualizar progreso PuLP
       if (data.pulp_progress) {


### PR DESCRIPTION
## Summary
- compact PuLP pattern data before writing partial results to generate charts without heavy payloads
- refresh handler paints coverage/deficit/excess charts only when chart data exists

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68b79e25b03c832783eb476fd35d7ded