### PR TITLE
Add CSRF token to generator form

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, request, current_app, jsonify
+from flask_wtf.csrf import generate_csrf
 from . import scheduler
 
 bp = Blueprint("generator", __name__)
@@ -34,7 +35,10 @@ def _cfg_from_request(form):
 def generador():
     if request.method == "GET":
         # Muestra formulario simple de carga (sin JS, sin polling)
-        return render_template("generador.html", mode="sync")
+        # Genera token CSRF y pásalo al template
+        return render_template(
+            "generador.html", mode="sync", csrf_token=generate_csrf()
+        )
 
     # POST: ejecutar TODO en la MISMA request (modo Streamlit)
     xls = request.files.get("file") or request.files.get("excel")

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -2,6 +2,8 @@
   <div class="card-body">
     <h5>Ejecutar (modo Streamlit, síncrono)</h5>
     <form action="/generador" method="POST" enctype="multipart/form-data">
+      <!-- Token CSRF obligatorio para Flask-WTF -->
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
       <div class="mb-2">
         <input type="file" name="file" accept=".xlsx,.xls" required />
       </div>


### PR DESCRIPTION
## Summary
- Generate CSRF token in generator route and pass it to template
- Include CSRF token hidden input in generator template form

## Testing
- `pytest -q` *(fails: SyntaxError in website/scheduler.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cee01ac48327ac14936449723b70