### PR TITLE
Comment out stray text causing syntax error

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -2716,7 +2716,7 @@ def generate_shift_patterns(demand_matrix, *, top_k=20, cfg=None):
     best = [it for it in items if it[0] == max_score]
     if len(best) >= k:
         return best[:k]
-ximo duplicando el mejor
+# ximo duplicando el mejor
     out = list(best)
     while len(out) < k:
         s, name, pat = best[0]


### PR DESCRIPTION
## Summary
- comment out stray `ximo duplicando el mejor` line in scheduler to avoid syntax error while keeping duplication logic intact

## Testing
- `pip install -r requirements.txt` *(fails: Cannot import 'setuptools.build_meta')*
- `python run.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68b8da63c2748327b436ac5945021a4c