### PR TITLE
Fix missing scheduler imports

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -36,6 +36,12 @@ except Exception:  # pragma: no cover - optional dependency
     psutil = None
 
 from typing import Dict, List, Iterable, Union
+try:
+    from .scheduler_core import load_demand_matrix_from_df, analyze_demand_matrix
+except Exception:  # pragma: no cover - allow script execution
+    import os, sys
+    sys.path.append(os.path.dirname(__file__))
+    from scheduler_core import load_demand_matrix_from_df, analyze_demand_matrix
 
 try:
     import pulp


### PR DESCRIPTION
## Summary
- expose `load_demand_matrix_from_df` and `analyze_demand_matrix` by importing from `scheduler_core`
- allow running `run_complete_optimization` without NameError

## Testing
- `python - <<'PY'
from flask import Flask
import pandas as pd
from io import BytesIO
from website.scheduler import run_complete_optimization
app=Flask(__name__)
with app.app_context():
    df=pd.DataFrame({'Día':[1],'Horario':['9'],'Suma de Agentes Requeridos Erlang':[1]})
    bio=BytesIO()
    with pd.ExcelWriter(bio, engine='openpyxl') as writer:
        df.to_excel(writer, index=False)
    bio.seek(0)
    result=run_complete_optimization(bio, config={'max_patterns':1,'batch_size':10,'use_ft':False,'use_pt':True,'allow_pt_4h':True,'allow_pt_6h':False,'allow_pt_5h':False,'optimization_profile':'JEAN','TIME_SOLVER':5})
    print(result['analysis'])
PY`
- `pytest` *(fails: ImportError: cannot import name 'run_complete_optimization' from '<unknown module name>' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_68b8e5ccf3e0832790d6f948ac8154d0