### PR TITLE
Use logging for scheduler initialization messages

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -20,6 +20,7 @@ import math
 from collections import defaultdict
 import re
 import base64
+import logging
 
 try:
     import matplotlib
@@ -37,13 +38,15 @@ except Exception:  # pragma: no cover - optional dependency
 
 from typing import Dict, List, Iterable, Union
 
+logger = logging.getLogger(__name__)
+
 try:
     import pulp
     PULP_AVAILABLE = True
 except ImportError:
     PULP_AVAILABLE = False
 
-print(f"[OPTIMIZER] PuLP disponible: {PULP_AVAILABLE}")
+logger.info(f"[OPTIMIZER] PuLP disponible: {PULP_AVAILABLE}")
 
 from threading import RLock, current_thread
 from functools import wraps


### PR DESCRIPTION
## Summary
- replace `print` with `logger.info` in `website/scheduler.py`
- initialize module-level logger to respect logging configuration

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'run_complete_optimization')*


------
https://chatgpt.com/codex/tasks/task_e_68b8e5ce14d083279ab8d71bf75a634e