### PR TITLE
Remove unused scheduler imports and job registry

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -5,7 +5,6 @@ import time
 import os
 import gc
 import hashlib
-import signal
 import io
 from io import BytesIO, StringIO
 from itertools import combinations, permutations, product
@@ -47,12 +46,8 @@ print(f"[OPTIMIZER] PuLP disponible: {PULP_AVAILABLE}")
 
 from threading import RLock, current_thread
 from functools import wraps
-import ctypes
 
 _MODEL_LOCK = RLock()
-
-# Registry of active optimization jobs
-active_jobs = {}
 
 # Bridge helpers to the shared store in website.extensions
 try:


### PR DESCRIPTION
## Summary
- drop unused `signal` and `ctypes` imports in `website/scheduler`
- remove unused `active_jobs` dictionary

## Testing
- `pytest tests/test_top_k_patterns.py::test_generate_shift_patterns_top_k -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e5d058d483278d5f39953045f6c3