### PR TITLE
Refactor generator blueprint and add scheduler helpers

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -1,20 +1,7 @@
 from flask import Flask
 from .generator_routes import bp as generator_bp
-try:
-    from flask_wtf.csrf import CSRFProtect
-    csrf = CSRFProtect()
-except Exception:  # pragma: no cover - optional dependency
-    csrf = None
-
 
 def create_app():
     app = Flask(__name__)
-    # Registrar solo el blueprint síncrono
     app.register_blueprint(generator_bp)
-
-    # Habilitar CSRF si está disponible y eximir el blueprint
-    if csrf:
-        csrf.init_app(app)
-        csrf.exempt(generator_bp)
-
     return app

--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -1,72 +1,50 @@
-from flask import Blueprint, render_template, request, current_app, jsonify
-from .scheduler import run_complete_optimization as run_opt
-
-# (Opcional pero recomendado) Si usas CSRFProtect, exime este blueprint:
-try:
-    # En __init__.py habrá un objeto csrf registrado en app.extensions["csrf"]
-    from flask import current_app as _current_app
-    _csrf = _current_app.extensions.get("csrf")  # puede ser None aquí si aún no hay app context
-except Exception:
-    _csrf = None
+from flask import Blueprint, render_template, request, jsonify
+from .scheduler import run_complete_optimization
 
 bp = Blueprint("generator", __name__)
 
-
 def _cfg_from_request(form):
+    # Mapea 1:1 con tus controles de Streamlit (nombres y defaults)
     return {
-        "profile": form.get("profile", "JEAN"),
-        "use_ft": form.get("use_ft", "true") == "true",
-        "use_pt": form.get("use_pt", "true") == "true",
-        "allow_8h": True,
-        "allow_10h8": True,
-        "allow_pt_4h": True,
-        "allow_pt_5h": True,
-        "allow_pt_6h": True,
+        "MAX_ITER": int(form.get("max_iter", 30)),
+        "TIME_SOLVER": (lambda v: None if int(v) == 0 else float(v))(form.get("time_solver", 0)),
+        "SOLVER_MSG": int(form.get("solver_msg", 1)),
+        "SOLVER_THREADS": int(form.get("solver_threads", 1)),
+        "TARGET_COVERAGE": float(form.get("coverage", 98)),
+        "VERBOSE": form.get("verbose", "0") == "1",
+
+        "use_ft": form.get("use_ft", "1") == "1",
+        "use_pt": form.get("use_pt", "1") == "1",
+
+        "allow_8h": form.get("allow_8h", "1") == "1",
+        "allow_10h8": form.get("allow_10h8", "0") == "1",
+
+        "allow_pt_4h": form.get("allow_pt_4h", "1") == "1",
+        "allow_pt_5h": form.get("allow_pt_5h", "1") == "1",
+        "allow_pt_6h": form.get("allow_pt_6h", "0") == "1",
+
         "break_from_start": float(form.get("break_from_start", 2)),
         "break_from_end": float(form.get("break_from_end", 2)),
-        # MÁS RÁPIDO por defecto que tu job async: 15s como en tu Streamlit
-        "solver_time": int(form.get("solver_time", current_app.config.get("TIME_SOLVER", 15))),
-        "solver_msg": True,
-        "coverage": float(form.get("coverage", 98)),
+
+        # Perfil JEAN por defecto (como tu app)
+        "optimization_profile": form.get("profile", "JEAN"),
         "agent_limit_factor": int(form.get("agent_limit_factor", 30)),
         "excess_penalty": float(form.get("excess_penalty", 5)),
         "peak_bonus": float(form.get("peak_bonus", 2)),
         "critical_bonus": float(form.get("critical_bonus", 2.5)),
-        # Para respuesta instantánea al probar: 2 iteraciones como base
-        "iterations": int(form.get("iterations", 2)),
-        "use_pulp": True,
-        "use_greedy": True,
-        "export_files": False,
-        "ft_first_pt_last": True,
-        "optimization_profile": form.get("optimization_profile", "JEAN"),
     }
-
 
 @bp.route("/generador", methods=["GET", "POST"])
 def generador():
-    # Eximir CSRF en runtime si existe (evita 400 “The CSRF token is missing”)
-    try:
-        app = current_app._get_current_object()
-        csrf_ext = app.extensions.get("csrf")
-        if csrf_ext:
-            csrf_ext.exempt(generador)
-    except Exception:
-        pass
-
     if request.method == "GET":
-        return render_template("generador.html", mode="sync")
+        return render_template("generador.html")
 
-    # POST: ejecutar TODO en la MISMA request (modo Streamlit)
-    xls = request.files.get("file") or request.files.get("excel")
+    xls = request.files.get("file")
     if not xls:
         return jsonify({"error": "Falta el archivo Excel"}), 400
 
     cfg = _cfg_from_request(request.form)
-    payload = run_opt(
-        xls,
-        config=cfg,
-        generate_charts=True,
-        job_id=None,
-        return_payload=True,  # <- devuelve figuras/base64 y métricas
+    payload = run_complete_optimization(
+        xls, config=cfg, generate_charts=True, job_id=None, return_payload=True
     )
-    return render_template("resultados.html", payload=payload, mode="sync")
+    return render_template("resultados.html", payload=payload)

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -1,39 +1,106 @@
-<div class="container py-4">
-  <div class="row justify-content-center">
-    <div class="col-lg-8">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="card-title mb-3">Optimización (modo Streamlit)</h5>
-          <form action="/generador" method="POST" enctype="multipart/form-data">
-            <!-- Si usas CSRFProtect y tienes el helper, inclúyelo -->
-            {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
-            <div class="mb-3">
-              <label class="form-label">Archivo de demanda (.xlsx)</label>
-              <input class="form-control" type="file" name="file" accept=".xlsx,.xls" required />
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <title>Generador de Turnos v6.2 - Sistema Corregido</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body{background:#0e1117;color:#e6e6e6}
+    .card{background:#161a23;border:1px solid #2b2f3a}
+    .form-label{font-weight:600}
+    .sidebar{min-width:290px}
+    input[type="number"], input[type="text"], input[type="file"], select{background:#0e1117;color:#e6e6e6;border:1px solid #2b2f3a}
+    .btn-primary{background:#1565c0;border:none}
+  </style>
+</head>
+<body>
+<div class="container-fluid py-3">
+  <h3 class="mb-3">Generador de Turnos v6.2 - Sistema Corregido</h3>
+
+  <form action="/generador" method="POST" enctype="multipart/form-data">
+    <div class="row g-3">
+      <!-- izquierda: configuración (equivalente al sidebar de Streamlit) -->
+      <div class="col-12 col-md-3">
+        <div class="card sidebar">
+          <div class="card-body">
+            <h5 class="card-title">⚙️ Configuración</h5>
+
+            <label class="form-label mt-2">Iteraciones máximas</label>
+            <input type="number" name="max_iter" value="30" min="1" max="100" class="form-control">
+
+            <label class="form-label mt-2">Tiempo solver (s)</label>
+            <input type="number" name="time_solver" value="0" min="0" max="600" class="form-control">
+
+            <label class="form-label mt-2">Mostrar progreso solver</label>
+            <select name="solver_msg" class="form-select">
+              <option value="1" selected>1</option>
+              <option value="0">0</option>
+            </select>
+
+            <label class="form-label mt-2">Threads solver (PuLP)</label>
+            <input type="number" name="solver_threads" value="1" min="1" class="form-control">
+
+            <label class="form-label mt-2">Cobertura objetivo (%)</label>
+            <input type="number" name="coverage" value="98" min="95" max="100" class="form-control">
+
+            <div class="form-check mt-2">
+              <input class="form-check-input" type="checkbox" name="verbose" value="1" id="v1">
+              <label class="form-check-label" for="v1">Modo verbose/debug</label>
             </div>
-            <div class="row g-2">
-              <div class="col">
-                <label class="form-label">Cobertura objetivo %</label>
-                <input class="form-control" type="number" name="coverage" value="98" />
+
+            <hr>
+            <h6>📋 Tipos de Contrato</h6>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="use_ft" value="1" id="ft1" checked>
+              <label class="form-check-label" for="ft1">Full Time (48h)</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="use_pt" value="1" id="pt1" checked>
+              <label class="form-check-label" for="pt1">Part Time (24h)</label>
+            </div>
+
+            <div id="ftcfg" class="mt-2">
+              <h6>⏰ Turnos FT Permitidos</h6>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="allow_8h" value="1" id="a8" checked>
+                <label class="form-check-label" for="a8">8 horas (6 días)</label>
               </div>
-              <div class="col">
-                <label class="form-label">Tiempo solver (s)</label>
-                <input class="form-control" type="number" name="solver_time" value="15" />
-              </div>
-              <div class="col">
-                <label class="form-label">Iteraciones JEAN</label>
-                <input class="form-control" type="number" name="iterations" value="2" />
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="allow_10h8" value="1" id="a108">
+                <label class="form-check-label" for="a108">10h + día de 8h (5 días)</label>
               </div>
             </div>
-            <input type="hidden" name="profile" value="JEAN"/>
-            <input type="hidden" name="use_ft" value="true"/>
-            <input type="hidden" name="use_pt" value="true"/>
-            <div class="mt-3">
-              <button class="btn btn-primary" type="submit">Optimizar</button>
-            </div>
-          </form>
+
+            <h6 class="mt-2">🧰 Configuración de Breaks</h6>
+            <label class="form-label">Break desde inicio (horas)</label>
+            <input type="number" step="0.5" name="break_from_start" value="2" class="form-control">
+            <label class="form-label mt-2">Break antes del fin (horas)</label>
+            <input type="number" step="0.5" name="break_from_end" value="2" class="form-control">
+
+            <h6 class="mt-2">⏳ Turnos PT Permitidos</h6>
+            <div class="form-check"><input class="form-check-input" type="checkbox" name="allow_pt_4h" value="1" id="p4" checked><label class="form-check-label" for="p4">4 horas (6 días)</label></div>
+            <div class="form-check"><input class="form-check-input" type="checkbox" name="allow_pt_5h" value="1" id="p5" checked><label class="form-check-label" for="p5">5 horas (6 días)</label></div>
+            <div class="form-check"><input class="form-check-input" type="checkbox" name="allow_pt_6h" value="1" id="p6"><label class="form-check-label" for="p6">6 horas (4 días)</label></div>
+          </div>
         </div>
       </div>
+
+      <!-- derecha: carga y botón -->
+      <div class="col-12 col-md-9">
+        <div class="card">
+          <div class="card-body">
+            <h5>Optimización</h5>
+            <label class="form-label">Sube tu Excel de demanda (Requerido.xlsx)</label>
+            <input class="form-control" type="file" name="file" accept=".xlsx,.xls" required>
+            <div class="mt-3">
+              <button class="btn btn-primary btn-lg" type="submit">🚀 Ejecutar Optimización</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div>
-  </div>
+  </form>
 </div>
+</body>
+</html>

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -1,49 +1,50 @@
-{% if payload %}
-<div class="container py-4">
-  <div class="row">
-    <div class="col-12">
-      <div class="card shadow-sm mb-3">
-        <div class="card-body">
-          <h5 class="card-title">Resultado</h5>
-          <p class="card-text mb-0">
-            <strong>{{ payload.metrics.agents }}</strong> agentes •
-            cobertura <strong>{{ payload.metrics.coverage_percentage }}%</strong> •
-            déficit <strong>{{ payload.metrics.deficit }}</strong> •
-            exceso <strong>{{ payload.metrics.excess }}</strong>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <title>Resultados</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body{background:#0e1117;color:#e6e6e6}
+    .card{background:#161a23;border:1px solid #2b2f3a}
+    img{max-width:100%}
+  </style>
+</head>
+<body>
+<div class="container-fluid py-3">
   <div class="row g-3">
-    <div class="col-12 col-lg-4">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h6 class="card-title">Demanda</h6>
-          <img class="img-fluid" src="data:image/png;base64,{{ payload.figures.demand_png }}" />
+    <div class="col-12">
+      <div class="card"><div class="card-body">
+        <div class="row text-center">
+          <div class="col"><h6>👥 Total Agentes</h6><div class="fs-4">{{ payload.metrics.total_agents }}</div></div>
+          <div class="col"><h6>📊 Cobertura Real</h6><div class="fs-4">{{ payload.metrics.coverage_real }}%</div></div>
+          <div class="col"><h6>✅ Cobertura Pura</h6><div class="fs-4">{{ payload.metrics.coverage_pure }}%</div></div>
+          <div class="col"><h6>⬆️ Exceso</h6><div class="fs-4">{{ payload.metrics.excess }}</div></div>
+          <div class="col"><h6>⬇️ Déficit</h6><div class="fs-4">{{ payload.metrics.deficit }}</div></div>
         </div>
-      </div>
+      </div></div>
     </div>
-    <div class="col-12 col-lg-4">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h6 class="card-title">Cobertura</h6>
-          <img class="img-fluid" src="data:image/png;base64,{{ payload.figures.coverage_png }}" />
+
+    <div class="col-12">
+      <ul class="nav nav-tabs" id="tabs" role="tablist">
+        <li class="nav-item" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t1" type="button">Demanda vs Cobertura</button></li>
+        <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t2" type="button">Diferencias</button></li>
+      </ul>
+      <div class="tab-content p-3 card">
+        <div class="tab-pane fade show active" id="t1">
+          <div class="row">
+            <div class="col-md-6"><h6>Demanda Requerida</h6><img src="data:image/png;base64,{{ payload.figures.demand_png }}"></div>
+            <div class="col-md-6"><h6>Cobertura Asignada</h6><img src="data:image/png;base64,{{ payload.figures.coverage_png }}"></div>
+          </div>
         </div>
-      </div>
-    </div>
-    <div class="col-12 col-lg-4">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h6 class="card-title">Exceso / Déficit</h6>
-          <img class="img-fluid" src="data:image/png;base64,{{ payload.figures.diff_png }}" />
+        <div class="tab-pane fade" id="t2">
+          <h6>Cobertura - Demanda (exceso/deficit)</h6>
+          <img src="data:image/png;base64,{{ payload.figures.diff_png }}">
         </div>
       </div>
     </div>
   </div>
 </div>
-{% else %}
-<div class="container py-4">
-  <div class="alert alert-warning">No hay resultados para mostrar.</div>
-</div>
-{% endif %}
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace generator routes with synchronous optimization blueprint
- Implement scheduler helpers for demand loading, pattern generation, chunked solving, and payload output
- Recreate Streamlit-like HTML templates and register only the generator blueprint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b918d832b483279079b43bd1c2b41f