### PR TITLE
feat(ui): refresh scheduling visuals with dark theme

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,40 +1,49 @@
 <!doctype html>
-<html lang="es" data-bs-theme="light">
+<html lang="es">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ title or 'Horarios' }}</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>{% block title %}Generador de Turnos{% endblock %}</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <!-- Bootstrap 5 + tema oscuro simple -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+
+  <style>
+    :root{
+      --bg:#0e1117; --card:#161a22; --muted:#9aa4b2; --text:#e6e6e6; --accent:#4c8bf5;
+      --success:#2ea043; --danger:#da3633; --warning:#d29922;
+    }
+    html,body{ background:var(--bg); color:var(--text); font-family: Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial; }
+    .container-wide{ max-width: 1400px; }
+    .card{ background:var(--card); border:1px solid rgba(255,255,255,.06); border-radius:14px; }
+    .card .card-title{ color:var(--text); font-weight:600; }
+    .form-label{ color:var(--muted); font-weight:500; }
+    .form-control, .form-select{
+      background:#0e1117; color:var(--text); border:1px solid rgba(255,255,255,.12);
+    }
+    .form-check-label{ color:var(--text); }
+    .btn-primary{ background:var(--accent); border-color:var(--accent); }
+    .badge-soft{ background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12); color:var(--text); }
+    img.plot{ width:100%; height:auto; image-rendering: -webkit-optimize-contrast; }
+    .metrics{ display:grid; grid-template-columns: repeat(4, minmax(180px,1fr)); gap:16px; }
+    .metric{ padding:14px; border-radius:12px; background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.06); }
+    .metric .k{ font-size:28px; font-weight:700; }
+    .metric .l{ font-size:13px; color:var(--muted); }
+    .sidebar{ width:340px; }
+    .content{ flex:1; min-width:0; }
+    a { color:#7aa2ff; text-decoration:none }
+    a:hover { text-decoration:underline }
+  </style>
+  {% block head %}{% endblock %}
 </head>
 <body>
-  <header>
-    <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom sticky-top">
-      <div class="container-xxl">
-        <a class="navbar-brand d-flex align-items-center" href="/">
-          <span class="brand-dot me-2" aria-hidden="true"></span>
-          <span class="fs-5 fw-semibold">Schedules</span>
-        </a>
-        <div class="collapse navbar-collapse">
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-            <li class="nav-item">
-              <a href="{{ url_for('generator.generador') }}" class="nav-link {{ 'active' if request.endpoint=='generator.generador' else '' }}">Generador</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-  </header>
-
-  <main class="container-xxl py-4">
-    {% block content %}{% endblock %}
-  </main>
+  <div class="container-fluid py-3">
+    <div class="container-wide mx-auto">
+      {% block body %}{% endblock %}
+    </div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -1,106 +1,80 @@
-<!doctype html>
-<html lang="es">
-<head>
-  <meta charset="utf-8"/>
-  <title>Generador de Turnos v6.2 - Sistema Corregido</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    body{background:#0e1117;color:#e6e6e6}
-    .card{background:#161a23;border:1px solid #2b2f3a}
-    .form-label{font-weight:600}
-    .sidebar{min-width:290px}
-    input[type="number"], input[type="text"], input[type="file"], select{background:#0e1117;color:#e6e6e6;border:1px solid #2b2f3a}
-    .btn-primary{background:#1565c0;border:none}
-  </style>
-</head>
-<body>
-<div class="container-fluid py-3">
-  <h3 class="mb-3">Generador de Turnos v6.2 - Sistema Corregido</h3>
+{% extends "base.html" %}
+{% block title %}Generador de Turnos — Modo Streamlit{% endblock %}
 
-  <form action="/generador" method="POST" enctype="multipart/form-data">
-    <div class="row g-3">
-      <!-- izquierda: configuración (equivalente al sidebar de Streamlit) -->
-      <div class="col-12 col-md-3">
-        <div class="card sidebar">
-          <div class="card-body">
-            <h5 class="card-title">⚙️ Configuración</h5>
+{% block body %}
+<h3 class="mb-3">Generador de Turnos v6.2 — Sistema Corregido</h3>
 
-            <label class="form-label mt-2">Iteraciones máximas</label>
-            <input type="number" name="max_iter" value="30" min="1" max="100" class="form-control">
+<div class="d-flex gap-3">
+  <!-- Sidebar -->
+  <div class="sidebar">
+    <div class="card mb-3">
+      <div class="card-body">
+        <h5 class="card-title mb-3">⚙️ Configuración</h5>
 
-            <label class="form-label mt-2">Tiempo solver (s)</label>
-            <input type="number" name="time_solver" value="0" min="0" max="600" class="form-control">
+        <form action="/generador" method="POST" enctype="multipart/form-data" id="form-opt">
 
-            <label class="form-label mt-2">Mostrar progreso solver</label>
-            <select name="solver_msg" class="form-select">
-              <option value="1" selected>1</option>
-              <option value="0">0</option>
-            </select>
+          <div class="mb-3">
+            <label class="form-label">Iteraciones JEAN</label>
+            <input class="form-control" type="number" name="iterations" value="3" min="1" max="10"/>
+          </div>
 
-            <label class="form-label mt-2">Threads solver (PuLP)</label>
-            <input type="number" name="solver_threads" value="1" min="1" class="form-control">
+          <div class="mb-3">
+            <label class="form-label">Tiempo solver (s)</label>
+            <input class="form-control" type="number" name="solver_time" value="120" min="5" step="5"/>
+          </div>
 
-            <label class="form-label mt-2">Cobertura objetivo (%)</label>
-            <input type="number" name="coverage" value="98" min="95" max="100" class="form-control">
+          <div class="mb-3">
+            <label class="form-label">Cobertura objetivo (%)</label>
+            <input class="form-control" type="number" name="coverage" value="98" min="80" max="100"/>
+          </div>
 
-            <div class="form-check mt-2">
-              <input class="form-check-input" type="checkbox" name="verbose" value="1" id="v1">
-              <label class="form-check-label" for="v1">Modo verbose/debug</label>
-            </div>
-
-            <hr>
-            <h6>📋 Tipos de Contrato</h6>
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" name="use_ft" value="1" id="ft1" checked>
-              <label class="form-check-label" for="ft1">Full Time (48h)</label>
-            </div>
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" name="use_pt" value="1" id="pt1" checked>
-              <label class="form-check-label" for="pt1">Part Time (24h)</label>
-            </div>
-
-            <div id="ftcfg" class="mt-2">
-              <h6>⏰ Turnos FT Permitidos</h6>
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="allow_8h" value="1" id="a8" checked>
-                <label class="form-check-label" for="a8">8 horas (6 días)</label>
-              </div>
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="allow_10h8" value="1" id="a108">
-                <label class="form-check-label" for="a108">10h + día de 8h (5 días)</label>
-              </div>
-            </div>
-
-            <h6 class="mt-2">🧰 Configuración de Breaks</h6>
+          <div class="mb-3">
             <label class="form-label">Break desde inicio (horas)</label>
-            <input type="number" step="0.5" name="break_from_start" value="2" class="form-control">
-            <label class="form-label mt-2">Break antes del fin (horas)</label>
-            <input type="number" step="0.5" name="break_from_end" value="2" class="form-control">
-
-            <h6 class="mt-2">⏳ Turnos PT Permitidos</h6>
-            <div class="form-check"><input class="form-check-input" type="checkbox" name="allow_pt_4h" value="1" id="p4" checked><label class="form-check-label" for="p4">4 horas (6 días)</label></div>
-            <div class="form-check"><input class="form-check-input" type="checkbox" name="allow_pt_5h" value="1" id="p5" checked><label class="form-check-label" for="p5">5 horas (6 días)</label></div>
-            <div class="form-check"><input class="form-check-input" type="checkbox" name="allow_pt_6h" value="1" id="p6"><label class="form-check-label" for="p6">6 horas (4 días)</label></div>
+            <input class="form-control" type="number" step="0.5" name="break_from_start" value="2"/>
           </div>
-        </div>
-      </div>
 
-      <!-- derecha: carga y botón -->
-      <div class="col-12 col-md-9">
-        <div class="card">
-          <div class="card-body">
-            <h5>Optimización</h5>
-            <label class="form-label">Sube tu Excel de demanda (Requerido.xlsx)</label>
-            <input class="form-control" type="file" name="file" accept=".xlsx,.xls" required>
-            <div class="mt-3">
-              <button class="btn btn-primary btn-lg" type="submit">🚀 Ejecutar Optimización</button>
-            </div>
+          <div class="mb-3">
+            <label class="form-label">Break antes del fin (horas)</label>
+            <input class="form-control" type="number" step="0.5" name="break_from_end" value="2"/>
           </div>
-        </div>
-      </div>
 
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" id="ft" name="use_ft" value="true" checked>
+            <label class="form-check-label" for="ft">Full Time (48h)</label>
+          </div>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="pt" name="use_pt" value="true" checked>
+            <label class="form-check-label" for="pt">Part Time (24h)</label>
+          </div>
+
+          <!-- ocultos fijos para igualar a tu perfil JEAN -->
+          <input type="hidden" name="profile" value="JEAN"/>
+          <input type="hidden" name="agent_limit_factor" value="30"/>
+          <input type="hidden" name="excess_penalty" value="5"/>
+          <input type="hidden" name="peak_bonus" value="2"/>
+          <input type="hidden" name="critical_bonus" value="2.5"/>
+          <input type="hidden" name="optimization_profile" value="JEAN"/>
+
+          <hr class="my-3" />
+          <div class="mb-3">
+            <label class="form-label">Archivo de demanda (.xlsx)</label>
+            <input class="form-control" type="file" name="file" accept=".xlsx,.xls" required/>
+          </div>
+
+          <button class="btn btn-primary w-100" type="submit">🚀 Ejecutar Optimización</button>
+        </form>
+      </div>
     </div>
-  </form>
+  </div>
+
+  <!-- Contenido principal -->
+  <div class="content">
+    <div class="card">
+      <div class="card-body">
+        <div class="badge badge-soft">Modo Streamlit (síncrono)</div>
+        <div class="mt-2 text-muted">Sube tu Excel y se calculará todo en esta misma página.</div>
+      </div>
+    </div>
+  </div>
 </div>
-</body>
-</html>
+{% endblock %}

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -1,50 +1,58 @@
-<!doctype html>
-<html lang="es">
-<head>
-  <meta charset="utf-8"/>
-  <title>Resultados</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    body{background:#0e1117;color:#e6e6e6}
-    .card{background:#161a23;border:1px solid #2b2f3a}
-    img{max-width:100%}
-  </style>
-</head>
-<body>
-<div class="container-fluid py-3">
-  <div class="row g-3">
-    <div class="col-12">
-      <div class="card"><div class="card-body">
-        <div class="row text-center">
-          <div class="col"><h6>👥 Total Agentes</h6><div class="fs-4">{{ payload.metrics.total_agents }}</div></div>
-          <div class="col"><h6>📊 Cobertura Real</h6><div class="fs-4">{{ payload.metrics.coverage_real }}%</div></div>
-          <div class="col"><h6>✅ Cobertura Pura</h6><div class="fs-4">{{ payload.metrics.coverage_pure }}%</div></div>
-          <div class="col"><h6>⬆️ Exceso</h6><div class="fs-4">{{ payload.metrics.excess }}</div></div>
-          <div class="col"><h6>⬇️ Déficit</h6><div class="fs-4">{{ payload.metrics.deficit }}</div></div>
-        </div>
-      </div></div>
-    </div>
+{% extends "base.html" %}
+{% block title %}Resultados — Generador de Turnos{% endblock %}
 
-    <div class="col-12">
-      <ul class="nav nav-tabs" id="tabs" role="tablist">
-        <li class="nav-item" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t1" type="button">Demanda vs Cobertura</button></li>
-        <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t2" type="button">Diferencias</button></li>
-      </ul>
-      <div class="tab-content p-3 card">
-        <div class="tab-pane fade show active" id="t1">
-          <div class="row">
-            <div class="col-md-6"><h6>Demanda Requerida</h6><img src="data:image/png;base64,{{ payload.figures.demand_png }}"></div>
-            <div class="col-md-6"><h6>Cobertura Asignada</h6><img src="data:image/png;base64,{{ payload.figures.coverage_png }}"></div>
-          </div>
+{% block body %}
+<h3 class="mb-3">Resultados de Optimización</h3>
+
+{% if payload %}
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="metrics">
+        <div class="metric">
+          <div class="k">{{ payload.metrics.agents }}</div>
+          <div class="l">Agentes asignados</div>
         </div>
-        <div class="tab-pane fade" id="t2">
-          <h6>Cobertura - Demanda (exceso/deficit)</h6>
-          <img src="data:image/png;base64,{{ payload.figures.diff_png }}">
+        <div class="metric">
+          <div class="k">{{ payload.metrics.coverage_percentage }}%</div>
+          <div class="l">Cobertura</div>
+        </div>
+        <div class="metric">
+          <div class="k">{{ payload.metrics.excess }}</div>
+          <div class="l">Exceso (agentes-hora)</div>
+        </div>
+        <div class="metric">
+          <div class="k">{{ payload.metrics.deficit }}</div>
+          <div class="l">Déficit (agentes-hora)</div>
         </div>
       </div>
     </div>
   </div>
+
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title mb-2">Demanda por Hora y Día</h5>
+      <img class="plot" src="data:image/png;base64,{{ payload.figures.demand_png }}" alt="Demanda"/>
+    </div>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title mb-2">Cobertura por Hora y Día</h5>
+      <img class="plot" src="data:image/png;base64,{{ payload.figures.coverage_png }}" alt="Cobertura"/>
+    </div>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title mb-2">Cobertura - Demanda (exceso/déficit)</h5>
+      <img class="plot" src="data:image/png;base64,{{ payload.figures.diff_png }}" alt="Diferencias"/>
+    </div>
+  </div>
+{% else %}
+  <div class="alert alert-warning">No hay resultados para mostrar.</div>
+{% endif %}
+
+<div class="mt-3">
+  <a href="/generador" class="btn btn-outline-light">← Nueva optimización</a>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- enhance heatmaps with high-DPI, dark-style rendering and dynamic annotation colors
- introduce dark-themed base template and streamlit-style generator form
- show results with metric grid and large plots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91b6ba1188327b2568d5780196336