### PR TITLE
feat: sync generator UI and metrics

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,150 +1,66 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
-/* =========================
-   TOKENS (CLARO / OSCURO)
-   ========================= */
 :root{
-  --brand: #2d6cdf;
-  --brand-600:#1f5ad1;
-
-  --ink:#111827;
-  --muted:#6b7280;
-
-  --bg-soft:#f7f8fb;   /* fondo suaves de secciones */
-  --page:#ffffff;      /* fondo de página */
-  --card:#ffffff;      /* cards */
-  --card-bd:#eef1f6;   /* borde cards */
+  --bg: #0e1117;
+  --panel:#161a22;
+  --panel-2:#1e2430;
+  --text:#e8eaec;
+  --muted:#b8bfcc;
+  --accent:#6ea8fe;
+  --primary:#6a5acd;
+  --ok:#16a34a;
+  --danger:#ef4444;
 }
-
-[data-bs-theme="dark"]{
-  --ink:#e5e7eb;
-  --muted:#9aa4b2;
-
-  --bg-soft:#0f141b;
-  --page:#0b1118;
-  --card:#1d2430;
-  --card-bd:#2a3240;
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0;
+  font-family:Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  background:var(--bg);
+  color:var(--text);
 }
-
-/* =========================
-   BASE
-   ========================= */
-html,body {
-  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif;
-  background: var(--page);
-  color: var(--ink);
-  transition: color .25s ease, background-color .25s ease;
+h1,h2,h3,h4{font-weight:800; letter-spacing:.2px}
+h1{font-size:2.2rem}
+h2{font-size:1.25rem}
+label{font-weight:600; color:var(--muted); font-size:.9rem}
+input,select{
+  width:100%;
+  background:#0f1523;
+  color:var(--text);
+  border:1px solid #2a3242;
+  border-radius:10px;
+  padding:10px 12px;
+  outline:none;
 }
-
-.card {
-  border-radius: 1rem;
-  border: 1px solid var(--card-bd);
-  background: var(--card);
-  box-shadow: 0 .75rem 1.5rem rgba(0,0,0,.05);
+input[type="checkbox"]{width:auto; accent-color:var(--primary)}
+.row{display:grid; grid-template-columns:360px 1fr; gap:28px; align-items:start}
+.card{
+  background:var(--panel);
+  border:1px solid #22293a;
+  border-radius:14px;
+  padding:18px;
+  box-shadow:0 6px 20px rgba(0,0,0,.35);
 }
-[data-bs-theme="dark"] .card {
-  box-shadow: 0 1.25rem 2.5rem rgba(0,0,0,.35);
+.section-title{font-size:1.05rem; font-weight:800; margin:10px 0 14px}
+.pill{display:inline-block; padding:6px 10px; border-radius:999px; background:#0f1523; color:var(--muted); border:1px solid #263046; font-weight:600; font-size:.85rem}
+.btn{
+  display:inline-flex; align-items:center; justify-content:center;
+  gap:10px; padding:12px 16px; font-weight:800; letter-spacing:.2px;
+  border-radius:12px; border:0; cursor:pointer; color:white;
+  background:linear-gradient(135deg,#6a5acd,#3b82f6);
 }
-
-/* =========================
-   KPI STAT CARDS
-   ========================= */
-.stat-card {
-  padding: 16px 20px;
-  border-radius: 1rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-height: 100%;
+.grid-2{display:grid; grid-template-columns:1fr 1fr; gap:18px}
+.metric{
+  background:var(--panel-2); border:1px solid #273046; border-radius:12px; padding:14px;
 }
-
-.stat-card .small {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* =========================
-   NAVBAR / OFFCANVAS
-   ========================= */
-.navbar.bg-body-tertiary{
-  background: var(--card) !important;
-  border-bottom: 1px solid var(--card-bd) !important;
-}
-.offcanvas{
-  background: var(--card);
-  border-right: 1px solid var(--card-bd);
-}
-.offcanvas .nav-link{ color: var(--ink); }
-.offcanvas .nav-link.active, .offcanvas .nav-link:hover{ color: var(--brand); }
-
-/* =========================
-   BOTONES DE MARCA
-   ========================= */
-.btn-brand{ /* azul (si lo usas en otras pantallas) */
-  background: var(--brand); border-color: var(--brand);
-  color:#fff; border:none; border-radius:10px; padding:.55rem .9rem; font-weight:600;
-}
-.btn-brand:hover{ background: var(--brand-600); border-color: var(--brand-600); color:#fff; }
-
-/* =========================
-   CHECKOUT LOOK & FEEL
-   ========================= */
-.checkout-hero{ background: var(--bg-soft); }
-.shadow-soft{ box-shadow: 0 20px 45px rgba(0,0,0,.08); }
-[data-bs-theme="dark"] .shadow-soft{ box-shadow: 0 20px 45px rgba(0,0,0,.55); }
-
-.pay-card,.order-card{
-  background:var(--card); border:1px solid var(--card-bd); border-radius:18px;
-}
-.price-chip{
-  background: rgba(45,108,223,.12); color:var(--brand);
-  font-weight:700; padding:.35rem .7rem; border-radius:999px;
-}
-.secure-line{
-  display:flex; align-items:center; gap:.5rem; color:var(--muted);
-  background:var(--card); border:1px solid var(--card-bd); border-radius:12px; padding:.7rem 1rem;
-}
-.secure-line .bi{ color:#16a34a; }
-.badge-dot{
-  width:10px;height:10px;border-radius:50%;background:#00e676;
-  box-shadow:0 0 0 3px rgba(0,230,118,.15);
-}
-
-/* === Logo empresa: puntito VERDE como en el landing === */
-.brand-dot{
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #16a34a; /* verde principal */
-  box-shadow:
-    0 0 0 3px rgba(22,163,74,.18),   /* halo */
-    0 0 18px rgba(22,163,74,.45);    /* glow */
-  display: inline-block;
-  flex: 0 0 auto;
-  transform: translateY(1px);
-  animation: brandPulse 2.4s ease-in-out infinite;
-}
-@keyframes brandPulse{
-  0%,100%{ box-shadow:0 0 0 3px rgba(22,163,74,.18), 0 0 18px rgba(22,163,74,.45); }
-  50%    { box-shadow:0 0 0 5px rgba(22,163,74,.12), 0 0 26px rgba(22,163,74,.60); }
-}
-
-/* contraste en modo oscuro */
-[data-bs-theme="dark"] .brand-dot{
-  background:#22c55e;
-  box-shadow:
-    0 0 0 3px rgba(34,197,94,.18),
-    0 0 22px rgba(34,197,94,.60);
-}
-
-/* Auth */
-.auth-hero{min-height:calc(100vh - 80px);display:grid;grid-template-columns:1fr 1fr}
-.auth-side{
-  background:linear-gradient(135deg,#f0fdf4,#dcfce7);
-  display:flex;align-items:center;justify-content:center;flex-direction:column;text-align:center;padding:2rem
-}
-[data-bs-theme="dark"] .auth-side{background:linear-gradient(135deg,#0f1410,#17211a)}
-.auth-form{display:flex;align-items:center;justify-content:center;padding:2rem}
-.auth-card{width:100%;max-width:420px}
-
+.metric .k{font-size:1.8rem; font-weight:800}
+.muted{color:var(--muted)}
+.imgbox{background:var(--panel); border:1px solid #273046; border-radius:12px; padding:14px}
+.imgbox img{max-width:100%; display:block; border-radius:8px}
+.small{font-size:.85rem}
+.spacer{height:16px}
+.group{margin-bottom:16px}
+.split{display:grid; grid-template-columns:1fr 1fr; gap:12px}
+.divider{height:1px; background:#263046; margin:12px 0}
+.titlebar{display:flex; align-items:center; justify-content:space-between}
+.titlebar h1{margin:0}

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -1,118 +1,79 @@
 <!doctype html>
-<html lang="es" data-theme="dark">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>Generador de Turnos v6.2 - Sistema Corregido</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="/static/css/streamlit-dark.css" rel="stylesheet">
-</head>
-<body class="bg-app">
-
-<div class="container-xxl py-4">
-  <h1 class="app-title">Generador de Turnos v6.2 — Sistema Corregido</h1>
-
-  <div class="row g-4 mt-1">
-    <!-- SIDEBAR (idéntico a streamlit) -->
-    <div class="col-12 col-lg-4">
-      <div class="st-card">
-        <div class="d-flex align-items-center mb-2">
-          <div class="badge-dot me-2"></div>
-          <h5 class="mb-0">Configuración</h5>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Generador de Turnos v6.2 — Sistema Corregido</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+  </head>
+  <body>
+    <div class="container" style="max-width:1400px; margin:32px auto;">
+      <div class="titlebar">
+        <h1>Generador de Turnos v6.2 — Sistema Corregido</h1>
+      </div>
+      <div class="spacer"></div>
+      <div class="row">
+        <!-- Sidebar Config -->
+        <div class="card">
+          <div class="section-title">• Configuración</div>
+          <form action="/generador" method="POST" enctype="multipart/form-data" id="cfgForm">
+            <div class="group">
+              <label>Iteraciones JEAN</label>
+              <input type="number" name="iterations" value="3" min="1">
+            </div>
+            <div class="group">
+              <label>Tiempo solver (s)</label>
+              <input type="number" name="solver_time" value="120" min="0">
+              <div class="small muted">0 = sin límite (no recomendado en modo síncrono)</div>
+            </div>
+            <div class="group">
+              <label>Cobertura objetivo (%)</label>
+              <input type="number" name="coverage" value="98" min="80" max="100">
+            </div>
+            <div class="split">
+              <div class="group">
+                <label>Break desde inicio (horas)</label>
+                <input type="number" step="0.5" name="break_from_start" value="2">
+              </div>
+              <div class="group">
+                <label>Break antes del fin (horas)</label>
+                <input type="number" step="0.5" name="break_from_end" value="2">
+              </div>
+            </div>
+            <div class="divider"></div>
+            <div class="group">
+              <label>Tipos de Contrato</label><br>
+              <input type="checkbox" name="use_ft" checked> <span class="muted">Full Time (48h)</span><br>
+              <input type="checkbox" name="use_pt" checked> <span class="muted">Part Time (24h)</span>
+            </div>
+            <div class="divider"></div>
+            <div class="group">
+              <label>Perfil de Optimización</label>
+              <select name="optimization_profile">
+                <option value="JEAN" selected>JEAN</option>
+                <option value="Estandar">Estándar</option>
+                <option value="Aprendizaje Adaptativo">Aprendizaje Adaptativo</option>
+              </select>
+            </div>
+            <div class="divider"></div>
+            <div class="group">
+              <label>Archivo de demanda (.xlsx)</label>
+              <input type="file" name="file" accept=".xlsx,.xls" required>
+            </div>
+            <button class="btn" type="submit">🚀 Ejecutar Optimización</button>
+          </form>
         </div>
 
-        <form action="/generador" method="POST" enctype="multipart/form-data" id="form-sync">
-          <div class="mb-3">
-            <label class="form-label">Iteraciones JEAN</label>
-            <input type="number" min="1" max="30" step="1" name="iterations" value="3" class="form-control st-input">
+        <!-- Panel derecho -->
+        <div>
+          <div class="card">
+            <span class="pill">Modo Streamlit (síncrono)</span>
+            <div class="spacer"></div>
+            <div class="muted">Sube tu Excel y se calculará todo en esta misma página (sin jobs ni polling).</div>
           </div>
-
-          <div class="mb-3">
-            <label class="form-label">Tiempo solver (s)</label>
-            <input type="number" min="0" max="600" step="1" name="solver_time" value="120" class="form-control st-input">
-            <div class="form-text">0 = sin límite (no recomendado en modo síncrono)</div>
-          </div>
-
-          <div class="mb-3">
-            <label class="form-label">Cobertura objetivo (%)</label>
-            <input type="number" min="95" max="100" step="1" name="coverage" value="98" class="form-control st-input">
-          </div>
-
-          <div class="row">
-            <div class="col-6 mb-3">
-              <label class="form-label">Break desde inicio (horas)</label>
-              <input type="number" min="0" max="6" step="0.5" name="break_from_start" value="2" class="form-control st-input">
-            </div>
-            <div class="col-6 mb-3">
-              <label class="form-label">Break antes del fin (horas)</label>
-              <input type="number" min="0" max="6" step="0.5" name="break_from_end" value="2" class="form-control st-input">
-            </div>
-          </div>
-
-          <div class="st-divider"></div>
-
-          <div class="mb-2">
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" id="use_ft" name="use_ft" checked>
-              <label class="form-check-label" for="use_ft">Full Time (48h)</label>
-            </div>
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" id="use_pt" name="use_pt" checked>
-              <label class="form-check-label" for="use_pt">Part Time (24h)</label>
-            </div>
-          </div>
-
-          <div class="st-divider"></div>
-
-          <div class="mb-3">
-            <label class="form-label">Perfil de Optimización</label>
-            <select class="form-select st-input" name="profile">
-              <option>Equilibrado (Recomendado)</option>
-              <option>Conservador</option>
-              <option>Agresivo</option>
-              <option>Máxima Cobertura</option>
-              <option>Mínimo Costo</option>
-              <option>100% Cobertura Eficiente</option>
-              <option>100% Cobertura Total</option>
-              <option>Cobertura Perfecta</option>
-              <option>100% Exacto</option>
-              <option selected>JEAN</option>
-              <option>JEAN Personalizado</option>
-              <option>Personalizado</option>
-              <option>Aprendizaje Adaptativo</option>
-            </select>
-          </div>
-
-          <div class="st-divider"></div>
-
-          <div class="mb-3">
-            <label class="form-label">Archivo de demanda (.xlsx)</label>
-            <input class="form-control st-input" type="file" name="file" accept=".xlsx,.xls" required>
-          </div>
-
-          {% if error %}
-          <div class="alert alert-danger py-2">{{ error }}</div>
-          {% endif %}
-
-          <button class="btn btn-primary w-100 st-primary" type="submit">
-            🚀 Ejecutar Optimización
-          </button>
-        </form>
+        </div>
       </div>
     </div>
-
-    <!-- PANEL DERECHO (solo texto informativo como en Streamlit) -->
-    <div class="col-12 col-lg-8">
-      <div class="st-card">
-        <span class="pill">Modo Streamlit (síncrono)</span>
-        <p class="text-muted mb-0 mt-2">
-          Sube tu Excel y se calculará todo en esta misma página (sin jobs ni polling).
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
-
-</body>
+  </body>
 </html>
 

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -1,75 +1,65 @@
 <!doctype html>
-<html lang="es" data-theme="dark">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>Resultados — Generador de Turnos v6.2</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="/static/css/streamlit-dark.css" rel="stylesheet">
-</head>
-<body class="bg-app">
-<div class="container-xxl py-4">
-  <h1 class="app-title">Generador de Turnos v6.2 — Sistema Corregido</h1>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Resultado — Generador de Turnos v6.2</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+  </head>
+  <body>
+    <div class="container" style="max-width:1400px; margin:32px auto;">
+      <div class="titlebar">
+        <h1>Generador de Turnos v6.2 — Sistema Corregido</h1>
+      </div>
+      <div class="spacer"></div>
 
-  <!-- Banner de éxito estilo streamlit -->
-  <div class="st-card st-success d-flex align-items-center">
-    <div class="me-2">✅</div>
-    <div>
-      <strong>Optimización completada</strong>
-      <div class="small text-muted">Perfil: {{ cfg.profile }} &nbsp;•&nbsp; Cobertura objetivo: {{ cfg.coverage|int }}%</div>
-    </div>
-  </div>
+      {% if payload %}
+        <!-- KPIs -->
+        <div class="grid-2" style="grid-template-columns: repeat(5, 1fr); gap:14px;">
+          <div class="metric">
+            <div class="muted small">Total Agentes</div>
+            <div class="k">{{ payload.metrics.agents }}</div>
+          </div>
+          <div class="metric">
+            <div class="muted small">Cobertura Real</div>
+            <div class="k">{{ payload.metrics.coverage_real }}%</div>
+          </div>
+          <div class="metric">
+            <div class="muted small">Cobertura Pura</div>
+            <div class="k">{{ payload.metrics.coverage_pure }}%</div>
+          </div>
+          <div class="metric">
+            <div class="muted small">Exceso</div>
+            <div class="k">{{ payload.metrics.excess }}</div>
+          </div>
+          <div class="metric">
+            <div class="muted small">Déficit</div>
+            <div class="k">{{ payload.metrics.deficit }}</div>
+          </div>
+        </div>
 
-  <!-- Métricas -->
-  <div class="row g-3 mt-1">
-    <div class="col-6 col-md-3">
-      <div class="st-card st-metric">
-        <div class="metric-label">Total Agentes</div>
-        <div class="metric-value">{{ payload.metrics.agents }}</div>
-      </div>
-    </div>
-    <div class="col-6 col-md-3">
-      <div class="st-card st-metric">
-        <div class="metric-label">Cobertura Real</div>
-        <div class="metric-value">{{ payload.metrics.coverage_percentage }}%</div>
-      </div>
-    </div>
-    <div class="col-6 col-md-3">
-      <div class="st-card st-metric">
-        <div class="metric-label">Exceso</div>
-        <div class="metric-value">{{ payload.metrics.excess }}</div>
-      </div>
-    </div>
-    <div class="col-6 col-md-3">
-      <div class="st-card st-metric">
-        <div class="metric-label">Déficit</div>
-        <div class="metric-value">{{ payload.metrics.deficit }}</div>
-      </div>
-    </div>
-  </div>
+        <div class="spacer"></div>
+        <h2>📊 Análisis Visual</h2>
+        <div class="grid-2">
+          <div class="imgbox">
+            <div class="muted small" style="margin-bottom:8px">Demanda Requerida</div>
+            <img src="data:image/png;base64,{{ payload.figures.demand_png }}" alt="Demanda">
+          </div>
+          <div class="imgbox">
+            <div class="muted small" style="margin-bottom:8px">Cobertura Asignada</div>
+            <img src="data:image/png;base64,{{ payload.figures.coverage_png }}" alt="Cobertura">
+          </div>
+        </div>
 
-  <!-- Gráficos (idéntico layout: Demanda, Cobertura, Diferencias) -->
-  <div class="row g-4 mt-1">
-    <div class="col-12">
-      <div class="st-card">
-        <h5 class="mb-3">Demanda Requerida</h5>
-        <img class="w-100 st-img" src="data:image/png;base64,{{ payload.figures.demand_png }}" alt="Demanda">
-      </div>
+        <div class="spacer"></div>
+        <div class="imgbox">
+          <div class="muted small" style="margin-bottom:8px">Diferencias (Cobertura - Demanda)</div>
+          <img src="data:image/png;base64,{{ payload.figures.diff_png }}" alt="Diferencias">
+        </div>
+      {% else %}
+        <div class="card">No hay resultados para mostrar.</div>
+      {% endif %}
     </div>
-    <div class="col-12">
-      <div class="st-card">
-        <h5 class="mb-3">Cobertura Asignada</h5>
-        <img class="w-100 st-img" src="data:image/png;base64,{{ payload.figures.coverage_png }}" alt="Cobertura">
-      </div>
-    </div>
-    <div class="col-12">
-      <div class="st-card">
-        <h5 class="mb-3">Cobertura - Demanda (Exceso / Déficit)</h5>
-        <img class="w-100 st-img" src="data:image/png;base64,{{ payload.figures.diff_png }}" alt="Diferencias">
-      </div>
-    </div>
-  </div>
-</div>
-</body>
+  </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add coverage helpers and real/pure coverage metrics
- sync generator routes and templates with Streamlit flow
- add dark theme CSS for generator and results pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask'; pip installation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d0615b888327804c297f077b446d