### PR TITLE
Align generator templates with Streamlit layout

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -1,51 +1,106 @@
 from flask import Blueprint, render_template, request, current_app, jsonify
-from .scheduler import run_complete_optimization as run_opt
+import math
+
+# intenta leer bandera de PuLP desde tu core; si no existe, detecta localmente
+try:
+    from .scheduler import run_complete_optimization, PULP_AVAILABLE  # ya lo usas
+except Exception:
+    from .scheduler import run_complete_optimization
+    try:
+        import pulp  # type: ignore
+        PULP_AVAILABLE = True
+    except Exception:
+        PULP_AVAILABLE = False
 
 bp = Blueprint("generator", __name__)
 
+# Perfiles EXACTOS como en Streamlit (mismo orden y textos)
+# ref: st.sidebar.selectbox(... opciones ...)  :contentReference[oaicite:4]{index=4}
+PROFILE_OPTIONS = [
+    "Equilibrado (Recomendado)", "Conservador", "Agresivo",
+    "Máxima Cobertura", "Mínimo Costo",
+    "100% Cobertura Eficiente", "100% Cobertura Total",
+    "Cobertura Perfecta", "100% Exacto",
+    "JEAN", "JEAN Personalizado", "Personalizado", "Aprendizaje Adaptativo"
+]
 
-def _b(v):
-    return str(v).lower() in ("true", "1", "on", "yes", "si", "sí")
+
+def _get_bool(name, default=False):
+    v = request.form.get(name)
+    if v is None:
+        return default
+    return v in ("1", "true", "True", "on", "yes")
 
 
 def _cfg_from_request(form):
-    return {
-        "optimization_profile": form.get("optimization_profile", "JEAN"),
-        "use_ft": _b(form.get("use_ft", "on")),
-        "use_pt": _b(form.get("use_pt", "on")),
-        "break_from_start": float(form.get("break_from_start", 2)),
-        "break_from_end": float(form.get("break_from_end", 2)),
-        "solver_time": int(form.get("solver_time", current_app.config.get("TIME_SOLVER", 120))),
-        "coverage": float(form.get("coverage", 98)),
-        "iterations": int(form.get("iterations", 3)),
-        # constantes JEAN por defecto (idénticas a tu perfil)
-        "agent_limit_factor": int(form.get("agent_limit_factor", 30)),
-        "excess_penalty": float(form.get("excess_penalty", 5)),
-        "peak_bonus": float(form.get("peak_bonus", 2)),
-        "critical_bonus": float(form.get("critical_bonus", 2.5)),
-        "use_pulp": True,
-        "use_greedy": True,
-        "export_files": False,
-        "ft_first_pt_last": True,
+    # Controles y nombres igual que tu Streamlit sidebar
+    # ref: “Iteraciones máximas”, “Tiempo solver (s)”, “Cobertura objetivo (%)”, etc. :contentReference[oaicite:5]{index=5}
+    cfg = {
+        "iterations": int(form.get("max_iter", 30)),
+        "solver_time": (None if form.get("time_solver", "0") in ("0", "", None) else float(form.get("time_solver"))),
+        "solver_msg": int(form.get("solver_msg", 1)),
+        "solver_threads": int(form.get("solver_threads", 1)),
+        "coverage": float(form.get("target_coverage", 98)),
+        "verbose": _get_bool("verbose", False),
+
+        # Contratos y turnos (mismos textos)
+        "use_ft": _get_bool("use_ft", True),     # “Full Time (48h)” :contentReference[oaicite:6]{index=6}
+        "use_pt": _get_bool("use_pt", True),     # “Part Time (24h)”
+        "allow_8h": _get_bool("allow_8h", True),           # 8 horas (6 días) :contentReference[oaicite:7]{index=7}
+        "allow_10h8": _get_bool("allow_10h8", False),      # 10h + día de 8h (5 días)
+        "allow_pt_4h": _get_bool("allow_pt_4h", True),     # 4 horas (6 días) :contentReference[oaicite:8]{index=8}
+        "allow_pt_6h": _get_bool("allow_pt_6h", True),     # 6 horas (4 días)
+        "allow_pt_5h": _get_bool("allow_pt_5h", False),    # 5 horas (5 días)
+
+        # Breaks
+        "break_from_start": float(form.get("break_from_start", 2.5)),  # “Break desde inicio (horas)” :contentReference[oaicite:9]{index=9}
+        "break_from_end": float(form.get("break_from_end", 2.5)),      # “Break antes del fin (horas)” :contentReference[oaicite:10]{index=10}
+
+        # Perfil de optimización (selector)
+        "optimization_profile": form.get("optimization_profile", "Equilibrado (Recomendado)"),  # :contentReference[oaicite:11]{index=11}
     }
+
+    # Flags útiles para tu core
+    cfg["use_pulp"] = True
+    cfg["use_greedy"] = True
+
+    return cfg
 
 
 @bp.route("/generador", methods=["GET", "POST"])
 def generador():
     if request.method == "GET":
-        return render_template("generador.html", mode="sync")
+        return render_template(
+            "generador.html",
+            pulp_available=PULP_AVAILABLE,
+            profile_options=PROFILE_OPTIONS
+        )
 
+    # POST síncrono (modo Streamlit)
     xls = request.files.get("file") or request.files.get("excel")
     if not xls:
         return jsonify({"error": "Falta el archivo Excel"}), 400
 
     cfg = _cfg_from_request(request.form)
-    payload = run_opt(
+
+    payload = run_complete_optimization(
         xls,
         config=cfg,
         generate_charts=True,
         job_id=None,
         return_payload=True,
     )
-    return render_template("resultados.html", payload=payload, mode="sync")
+
+    # Fallbacks por si tu core no devuelve todo
+    payload.setdefault("analysis", {})
+    payload.setdefault("status", "ok")
+    payload.setdefault("elapsed", None)
+
+    return render_template(
+        "resultados.html",
+        payload=payload,
+        cfg=cfg,
+        pulp_available=PULP_AVAILABLE,
+        profile_options=PROFILE_OPTIONS
+    )
 

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,49 +1,37 @@
 <!doctype html>
-<html lang="es">
+<html lang="es" data-bs-theme="dark">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>{% block title %}Generador de Turnos{% endblock %}</title>
-
-  <!-- Bootstrap 5 + tema oscuro simple -->
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>{% block title %}Generador de Turnos v6.2 — Sistema Corregido{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-
   <style>
     :root{
-      --bg:#0e1117; --card:#161a22; --muted:#9aa4b2; --text:#e6e6e6; --accent:#4c8bf5;
-      --success:#2ea043; --danger:#da3633; --warning:#d29922;
+      --bg:#0e1117; --panel:#1c1f26; --muted:#9aa4b2; --text:#e8e8ea; --accent:#5b7cfa;
     }
-    html,body{ background:var(--bg); color:var(--text); font-family: Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial; }
-    .container-wide{ max-width: 1400px; }
-    .card{ background:var(--card); border:1px solid rgba(255,255,255,.06); border-radius:14px; }
-    .card .card-title{ color:var(--text); font-weight:600; }
-    .form-label{ color:var(--muted); font-weight:500; }
-    .form-control, .form-select{
-      background:#0e1117; color:var(--text); border:1px solid rgba(255,255,255,.12);
-    }
-    .form-check-label{ color:var(--text); }
-    .btn-primary{ background:var(--accent); border-color:var(--accent); }
-    .badge-soft{ background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12); color:var(--text); }
-    img.plot{ width:100%; height:auto; image-rendering: -webkit-optimize-contrast; }
-    .metrics{ display:grid; grid-template-columns: repeat(4, minmax(180px,1fr)); gap:16px; }
-    .metric{ padding:14px; border-radius:12px; background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.06); }
-    .metric .k{ font-size:28px; font-weight:700; }
-    .metric .l{ font-size:13px; color:var(--muted); }
-    .sidebar{ width:340px; }
-    .content{ flex:1; min-width:0; }
-    a { color:#7aa2ff; text-decoration:none }
-    a:hover { text-decoration:underline }
+    body{background:var(--bg); color:var(--text);}
+    .card{background:var(--panel); border:1px solid #2a2f3a;}
+    .form-label,.form-check-label,.badge{color:var(--text)}
+    .text-muted{color:var(--muted)!important}
+    .sidebar{width: 420px; max-width: 100%;}
+    .chip{display:inline-block; background:#212534; border:1px solid #2a2f3a; color:#bfc6d2; padding:.35rem .7rem; border-radius:999px; font-size:.85rem}
+    .btn-primary{background:#6c7cff;border-color:#6c7cff}
+    .btn-primary:hover{background:#5a6aff;border-color:#5a6aff}
+    .dropzone{border:1px dashed #3b4252; background:#141823; border-radius:.6rem; padding:1rem 1.25rem; color:#b7c0cd}
+    .nav-tabs .nav-link{color:#cbd2dc}
+    .nav-tabs .nav-link.active{background:#1f2430;border-color:#2c3240;color:#fff}
+    .metric{font-size:2rem; font-weight:700}
+    .metric-sublabel{font-size:.9rem; color:#aab2bf}
+    .list-dot li{ margin:.25rem 0 }
   </style>
   {% block head %}{% endblock %}
 </head>
 <body>
-  <div class="container-fluid py-3">
-    <div class="container-wide mx-auto">
-      {% block body %}{% endblock %}
-    </div>
+  <div class="container-xxl py-4">
+    {% block content %}{% endblock %}
   </div>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>
+

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -1,79 +1,163 @@
-<!doctype html>
-<html lang="es">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Generador de Turnos v6.2 — Sistema Corregido</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
-  </head>
-  <body>
-    <div class="container" style="max-width:1400px; margin:32px auto;">
-      <div class="titlebar">
-        <h1>Generador de Turnos v6.2 — Sistema Corregido</h1>
-      </div>
-      <div class="spacer"></div>
-      <div class="row">
-        <!-- Sidebar Config -->
-        <div class="card">
-          <div class="section-title">• Configuración</div>
-          <form action="/generador" method="POST" enctype="multipart/form-data" id="cfgForm">
-            <div class="group">
-              <label>Iteraciones JEAN</label>
-              <input type="number" name="iterations" value="3" min="1">
+{% extends "base.html" %}
+{% block title %}Generador de Turnos v6.2 — Sistema Corregido{% endblock %}
+
+{% block content %}
+  <h1 class="mb-4">Generador de Turnos v6.2 — Sistema Corregido</h1>
+
+  <div class="row g-4">
+    <!-- SIDEBAR -->
+    <div class="col-12 col-xl-4 col-lg-5">
+      <div class="card sidebar">
+        <div class="card-body">
+          <h5 class="mb-3">⚙️ Configuración</h5>
+
+          <form id="form-generador" action="/generador" method="POST" enctype="multipart/form-data">
+            <!-- Iteraciones / tiempo / solver -->
+            <div class="mb-3">
+              <label class="form-label">Iteraciones máximas</label>
+              <input class="form-control" type="number" name="max_iter" value="30" min="1" />
             </div>
-            <div class="group">
-              <label>Tiempo solver (s)</label>
-              <input type="number" name="solver_time" value="120" min="0">
-              <div class="small muted">0 = sin límite (no recomendado en modo síncrono)</div>
+            <div class="mb-3">
+              <label class="form-label">Tiempo solver (s)</label>
+              <input class="form-control" type="number" name="time_solver" value="240" min="0" />
+              <div class="form-text text-muted">0 = sin límite (no recomendado en modo síncrono)</div>
             </div>
-            <div class="group">
-              <label>Cobertura objetivo (%)</label>
-              <input type="number" name="coverage" value="98" min="80" max="100">
-            </div>
-            <div class="split">
-              <div class="group">
-                <label>Break desde inicio (horas)</label>
-                <input type="number" step="0.5" name="break_from_start" value="2">
-              </div>
-              <div class="group">
-                <label>Break antes del fin (horas)</label>
-                <input type="number" step="0.5" name="break_from_end" value="2">
-              </div>
-            </div>
-            <div class="divider"></div>
-            <div class="group">
-              <label>Tipos de Contrato</label><br>
-              <input type="checkbox" name="use_ft" checked> <span class="muted">Full Time (48h)</span><br>
-              <input type="checkbox" name="use_pt" checked> <span class="muted">Part Time (24h)</span>
-            </div>
-            <div class="divider"></div>
-            <div class="group">
-              <label>Perfil de Optimización</label>
-              <select name="optimization_profile">
-                <option value="JEAN" selected>JEAN</option>
-                <option value="Estandar">Estándar</option>
-                <option value="Aprendizaje Adaptativo">Aprendizaje Adaptativo</option>
+            <div class="mb-3">
+              <label class="form-label">Mostrar progreso solver</label>
+              <select class="form-select" name="solver_msg">
+                <option value="1" selected>1</option>
+                <option value="0">0</option>
               </select>
             </div>
-            <div class="divider"></div>
-            <div class="group">
-              <label>Archivo de demanda (.xlsx)</label>
-              <input type="file" name="file" accept=".xlsx,.xls" required>
+            <div class="mb-3">
+              <label class="form-label">Threads solver (PuLP)</label>
+              <input class="form-control" type="number" name="solver_threads" value="1" min="1" />
             </div>
-            <button class="btn" type="submit">🚀 Ejecutar Optimización</button>
+            <div class="mb-3">
+              <label class="form-label">Cobertura objetivo (%)</label>
+              <input class="form-control" type="number" name="target_coverage" value="98" min="95" max="100" />
+            </div>
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" name="verbose" id="verbose">
+              <label class="form-check-label" for="verbose">Modo verbose/debug</label>
+            </div>
+
+            <!-- Tipos de contrato -->
+            <h6 class="mt-4 mb-2">📋 Tipos de Contrato</h6>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="use_ft" id="use_ft" checked>
+              <label class="form-check-label" for="use_ft">Full Time (48h)</label>
+            </div>
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" name="use_pt" id="use_pt" checked>
+              <label class="form-check-label" for="use_pt">Part Time (24h)</label>
+            </div>
+
+            <!-- Turnos FT -->
+            <div id="ft_block">
+              <h6 class="mt-3 mb-2">⏰ Turnos FT Permitidos</h6>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="allow_8h" id="allow_8h" checked>
+                <label class="form-check-label" for="allow_8h">8 horas (6 días)</label>
+              </div>
+              <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" name="allow_10h8" id="allow_10h8">
+                <label class="form-check-label" for="allow_10h8">10h + día de 8h (5 días)</label>
+              </div>
+            </div>
+
+            <!-- Breaks -->
+            <h6 class="mt-3 mb-2">☕ Configuración de Breaks</h6>
+            <div class="row g-2">
+              <div class="col-6">
+                <label class="form-label">Break desde inicio (horas)</label>
+                <input class="form-control" type="number" step="0.5" name="break_from_start" value="2.5" min="1" max="5">
+              </div>
+              <div class="col-6">
+                <label class="form-label">Break antes del fin (horas)</label>
+                <input class="form-control" type="number" step="0.5" name="break_from_end" value="2.5" min="1" max="5">
+              </div>
+            </div>
+
+            <!-- Turnos PT -->
+            <div id="pt_block">
+              <h6 class="mt-3 mb-2">⏰ Turnos PT Permitidos</h6>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="allow_pt_4h" id="allow_pt_4h" checked>
+                <label class="form-check-label" for="allow_pt_4h">4 horas (6 días)</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="allow_pt_6h" id="allow_pt_6h" checked>
+                <label class="form-check-label" for="allow_pt_6h">6 horas (4 días)</label>
+              </div>
+              <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" name="allow_pt_5h" id="allow_pt_5h">
+                <label class="form-check-label" for="allow_pt_5h">5 horas (5 días)</label>
+              </div>
+            </div>
+
+            <!-- Perfil de optimización (el “selector de horarios” que te falta) -->
+            <h6 class="mt-4 mb-2">🎯 Perfil de Optimización</h6>
+            <select class="form-select" name="optimization_profile">
+              {% for opt in profile_options %}
+                <option value="{{opt}}" {% if opt=='JEAN' %}selected{% endif %}>{{opt}}</option>
+              {% endfor %}
+            </select>
+            {% if pulp_available %}
+              <div class="alert alert-success mt-3 py-2 mb-2">
+                🧠 <strong>Solver Inteligente Disponible</strong><br>Programación Lineal (PuLP)
+              </div>
+            {% else %}
+              <div class="alert alert-warning mt-3 py-2 mb-2">
+                🔄 <strong>Solver Básico Activo</strong><br>Instala <code>pip install pulp</code>
+              </div>
+            {% endif %}
+
+            <!-- Uploader y botón -->
+            <div class="mt-4">
+              <label class="form-label">Archivo de demanda (.xlsx)</label><br>
+              <input class="form-control" type="file" name="file" accept=".xlsx" required>
+            </div>
+
+            <button class="btn btn-primary w-100 mt-3" type="submit">
+              🚀 Ejecutar Optimización
+            </button>
           </form>
         </div>
+      </div>
+    </div>
 
-        <!-- Panel derecho -->
-        <div>
-          <div class="card">
-            <span class="pill">Modo Streamlit (síncrono)</span>
-            <div class="spacer"></div>
-            <div class="muted">Sube tu Excel y se calculará todo en esta misma página (sin jobs ni polling).</div>
+    <!-- ÁREA PRINCIPAL: chip “Modo Streamlit (síncrono)” y ayuda -->
+    <div class="col-12 col-xl-8 col-lg-7">
+      <div class="card">
+        <div class="card-body">
+          <span class="chip">Modo Streamlit (síncrono)</span>
+          <p class="mt-3 mb-0 text-muted">
+            Sube tu Excel y se calculará todo en esta misma página (sin jobs ni polling).
+          </p>
+          <div class="dropzone mt-3">
+            <strong>Tip:</strong> también puedes arrastrar el archivo al campo de la izquierda y presionar
+            <em>“🚀 Ejecutar Optimización”</em>.
           </div>
         </div>
       </div>
     </div>
-  </body>
-</html>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  const ft = document.getElementById('use_ft');
+  const pt = document.getElementById('use_pt');
+  const ftBlock = document.getElementById('ft_block');
+  const ptBlock = document.getElementById('pt_block');
+  function refreshBlocks(){
+    ftBlock.style.display = ft.checked ? '' : 'none';
+    ptBlock.style.display = pt.checked ? '' : 'none';
+  }
+  ft?.addEventListener('change', refreshBlocks);
+  pt?.addEventListener('change', refreshBlocks);
+  refreshBlocks();
+</script>
+{% endblock %}
 

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -1,65 +1,84 @@
-<!doctype html>
-<html lang="es">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Resultado — Generador de Turnos v6.2</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
-  </head>
-  <body>
-    <div class="container" style="max-width:1400px; margin:32px auto;">
-      <div class="titlebar">
-        <h1>Generador de Turnos v6.2 — Sistema Corregido</h1>
-      </div>
-      <div class="spacer"></div>
+{% extends "base.html" %}
+{% block title %}Resultados — Generador v6.2{% endblock %}
 
-      {% if payload %}
-        <!-- KPIs -->
-        <div class="grid-2" style="grid-template-columns: repeat(5, 1fr); gap:14px;">
-          <div class="metric">
-            <div class="muted small">Total Agentes</div>
-            <div class="k">{{ payload.metrics.agents }}</div>
-          </div>
-          <div class="metric">
-            <div class="muted small">Cobertura Real</div>
-            <div class="k">{{ payload.metrics.coverage_real }}%</div>
-          </div>
-          <div class="metric">
-            <div class="muted small">Cobertura Pura</div>
-            <div class="k">{{ payload.metrics.coverage_pure }}%</div>
-          </div>
-          <div class="metric">
-            <div class="muted small">Exceso</div>
-            <div class="k">{{ payload.metrics.excess }}</div>
-          </div>
-          <div class="metric">
-            <div class="muted small">Déficit</div>
-            <div class="k">{{ payload.metrics.deficit }}</div>
-          </div>
-        </div>
+{% block content %}
+  <h1 class="mb-3">Generador de Turnos v6.2 — Sistema Corregido</h1>
 
-        <div class="spacer"></div>
-        <h2>📊 Análisis Visual</h2>
-        <div class="grid-2">
-          <div class="imgbox">
-            <div class="muted small" style="margin-bottom:8px">Demanda Requerida</div>
-            <img src="data:image/png;base64,{{ payload.figures.demand_png }}" alt="Demanda">
-          </div>
-          <div class="imgbox">
-            <div class="muted small" style="margin-bottom:8px">Cobertura Asignada</div>
-            <img src="data:image/png;base64,{{ payload.figures.coverage_png }}" alt="Cobertura">
-          </div>
-        </div>
+  <div class="alert alert-success">
+    ✅ Optimización completada{% if payload.elapsed %} en {{ "%.1f"|format(payload.elapsed) }}s{% endif %}.
+  </div>
 
-        <div class="spacer"></div>
-        <div class="imgbox">
-          <div class="muted small" style="margin-bottom:8px">Diferencias (Cobertura - Demanda)</div>
-          <img src="data:image/png;base64,{{ payload.figures.diff_png }}" alt="Diferencias">
-        </div>
-      {% else %}
-        <div class="card">No hay resultados para mostrar.</div>
-      {% endif %}
+  <!-- Métricas principales -->
+  <div class="row g-3">
+    <div class="col-md-3">
+      <div class="card h-100"><div class="card-body">
+        <div class="metric">{{ payload.metrics.agents or 0 }}</div>
+        <div class="metric-sublabel">Total Agentes</div>
+      </div></div>
     </div>
-  </body>
-</html>
+    <div class="col-md-3">
+      <div class="card h-100"><div class="card-body">
+        <div class="metric">{{ payload.metrics.coverage_percentage or 0 }}%</div>
+        <div class="metric-sublabel">Cobertura Pura</div>
+      </div></div>
+    </div>
+    <div class="col-md-3">
+      <div class="card h-100"><div class="card-body">
+        <div class="metric">{{ payload.metrics.excess or 0 }}</div>
+        <div class="metric-sublabel">Exceso</div>
+      </div></div>
+    </div>
+    <div class="col-md-3">
+      <div class="card h-100"><div class="card-body">
+        <div class="metric">{{ payload.metrics.deficit or 0 }}</div>
+        <div class="metric-sublabel">Déficit</div>
+      </div></div>
+    </div>
+  </div>
+
+  <!-- Tabs de análisis visual como en Streamlit -->
+  <div class="card mt-4">
+    <div class="card-body">
+      <h5 class="mb-3">📊 Análisis Visual</h5>
+
+      <ul class="nav nav-tabs" role="tablist">
+        <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab1" role="tab">Demanda vs Cobertura</button></li>
+        <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab2" role="tab">Diferencias</button></li>
+      </ul>
+
+      <div class="tab-content pt-3">
+        <div class="tab-pane fade show active" id="tab1" role="tabpanel">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <h6 class="mb-2">Demanda Requerida</h6>
+              <img class="img-fluid rounded" src="data:image/png;base64,{{ payload.figures.demand_png }}" alt="Demanda">
+            </div>
+            <div class="col-md-6">
+              <h6 class="mb-2">Cobertura Asignada</h6>
+              <img class="img-fluid rounded" src="data:image/png;base64,{{ payload.figures.coverage_png }}" alt="Cobertura">
+            </div>
+          </div>
+        </div>
+        <div class="tab-pane fade" id="tab2" role="tabpanel">
+          <h6 class="mb-2">Cobertura - Demanda (exceso/déficit)</h6>
+          <img class="img-fluid rounded" src="data:image/png;base64,{{ payload.figures.diff_png }}" alt="Diferencias">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Panel informativo tipo “análisis de demanda” -->
+  {% if payload.analysis and payload.analysis.summary %}
+    <div class="card mt-4">
+      <div class="card-body">
+        <h5 class="mb-3">🔎 Análisis de demanda</h5>
+        <ul class="list-unstyled list-dot">
+          {% for line in payload.analysis.summary %}
+            <li>• {{ line }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
 


### PR DESCRIPTION
## Summary
- Rework generator route to parse full Streamlit-style options and handle PuLP availability
- Introduce dark Bootstrap base template and rebuild generator page with contract, break, and profile controls
- Add results template displaying key metrics and tabbed visual analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9d5d3e1788327ab2e8b1a5e4dccee