### PR TITLE
Remove thread configuration from solver setup

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -11,7 +11,6 @@ def _cfg_from_request():
         "iterations":           int(request.form.get("iterations", 30)),
         "solver_time":          int(request.form.get("solver_time", current_app.config.get("TIME_SOLVER", 240))),
         "solver_msg":           request.form.get("solver_msg", "1") == "1",
-        "threads":              int(request.form.get("threads", 1)),
         "coverage":             float(request.form.get("coverage", 98)),
         "use_ft":               _bool("use_ft"),
         "use_pt":               _bool("use_pt"),

--- a/website/optimizer_pulp.py
+++ b/website/optimizer_pulp.py
@@ -198,7 +198,6 @@ def optimize_with_pulp(shifts_coverage, demand_matrix, *, cfg=None, job_id=None)
             solver = pl.PULP_CBC_CMD(
                 msg=False,
                 timeLimit=int(solver_time or 10),
-                threads=max(1, (os.cpu_count() or 2) - 1),
             )
             try:
                 status = prob.solve(solver)
@@ -212,7 +211,6 @@ def optimize_with_pulp(shifts_coverage, demand_matrix, *, cfg=None, job_id=None)
                     simple_solver = pl.PULP_CBC_CMD(
                         timeLimit=int(solver_time or 10),
                         msg=False,
-                        threads=max(1, (os.cpu_count() or 2) - 1),
                     )
                     status = prob.solve(simple_solver)
                     print(f"[PULP] Solver simple status: {status}")

--- a/website/profile_optimizers.py
+++ b/website/profile_optimizers.py
@@ -100,7 +100,6 @@ def optimize_minimum_cost(shifts_coverage, demand_matrix, *, cfg=None):
         solver = pl.PULP_CBC_CMD(
             msg=cfg.get("solver_msg", 0),
             timeLimit=cfg.get("solver_time", 200),
-            threads=cfg["solver_threads"]
         )
         
         prob.solve(solver)
@@ -210,7 +209,6 @@ def optimize_maximum_coverage(shifts_coverage, demand_matrix, *, cfg=None):
         solver = pl.PULP_CBC_CMD(
             msg=cfg.get("solver_msg", 0),
             timeLimit=cfg.get("solver_time", 400),
-            threads=cfg["solver_threads"]
         )
         
         prob.solve(solver)
@@ -300,7 +298,6 @@ def optimize_conservative(shifts_coverage, demand_matrix, *, cfg=None):
         solver = pl.PULP_CBC_CMD(
             msg=cfg.get("solver_msg", 0),
             timeLimit=cfg.get("solver_time", 240),
-            threads=cfg["solver_threads"]
         )
         
         prob.solve(solver)
@@ -393,7 +390,6 @@ def optimize_aggressive(shifts_coverage, demand_matrix, *, cfg=None):
         solver = pl.PULP_CBC_CMD(
             msg=cfg.get("solver_msg", 0),
             timeLimit=cfg.get("solver_time", 180),
-            threads=cfg["solver_threads"],
             gapRel=0.05  # Gap más amplio para velocidad
         )
         
@@ -499,7 +495,6 @@ def optimize_perfect_coverage(shifts_coverage, demand_matrix, *, cfg=None):
         solver = pl.PULP_CBC_CMD(
             msg=cfg.get("solver_msg", 0),
             timeLimit=solver_time,
-            threads=cfg["solver_threads"],
             gapRel=0.001 if profile == "100% Exacto" else 0.01
         )
         

--- a/website/scheduler_core.py
+++ b/website/scheduler_core.py
@@ -48,7 +48,6 @@ DEFAULT_CONFIG = {
     "peak_bonus": 1.5,
     "critical_bonus": 2.0,
     "iterations": 30,
-    "solver_threads": os.cpu_count() or 1,
     "use_ft": True,
     "use_pt": True,
     "allow_8h": True,

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -33,12 +33,6 @@
             </select>
           </div>
 
-          <!-- Threads solver (PuLP) -->
-          <div class="mt-3">
-            <label class="form-label">Threads solver (PuLP)</label>
-            <input class="form-control" type="number" name="threads" value="1" min="1" />
-          </div>
-
           <!-- Cobertura objetivo -->
           <div class="mt-3">
             <label class="form-label">Cobertura objetivo (%)</label>


### PR DESCRIPTION
## Summary
- drop "Threads solver (PuLP)" control from generator template
- stop reading thread counts from incoming requests and purge thread usage from solvers
- simplify default scheduler config by removing solver thread settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9de8774b88327bd828bd40d733d51