### PR TITLE
Align web scheduler with Streamlit defaults and metrics

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -3,35 +3,33 @@ from .scheduler import run_complete_optimization as run_opt
 
 bp = Blueprint("generator", __name__)
 
-def _bool(name):  # checkbox helper
-    return request.form.get(name) is not None
-
 def _cfg_from_request():
+    form = request.form
     return {
-        "iterations":           int(request.form.get("iterations", 30)),
-        "solver_time":          int(request.form.get("solver_time", current_app.config.get("TIME_SOLVER", 240))),
-        "solver_msg":           request.form.get("solver_msg", "1") == "1",
-        "coverage":             float(request.form.get("coverage", 98)),
-        "use_ft":               _bool("use_ft"),
-        "use_pt":               _bool("use_pt"),
-        "allow_8h":             _bool("allow_8h"),
-        "allow_10h8":           _bool("allow_10h8"),
-        "allow_pt_4h":          _bool("allow_pt_4h"),
-        "allow_pt_5h":          _bool("allow_pt_5h"),
-        "allow_pt_6h":          _bool("allow_pt_6h"),
-        "break_from_start":     float(request.form.get("break_from_start", 2.0)),
-        "break_from_end":       float(request.form.get("break_from_end", 2.0)),
-        "optimization_profile": request.form.get("optimization_profile", "JEAN"),
-        "profile":              request.form.get("optimization_profile", "JEAN"),  # alias para legacy
-        "agent_limit_factor":   30,
-        "excess_penalty":       5.0,
-        "peak_bonus":           2.0,
-        "critical_bonus":       2.5,
-        "use_pulp":             True,
-        "use_greedy":           True,
-        "ft_first_pt_last":     True,
-        "export_files":         False,
-        "verbose":              _bool("verbose"),
+        "iterations": int(form.get("iterations", 30)),
+        "solver_time": int(form.get("solver_time", 240)),
+        "solver_msg": form.get("solver_msg", "1") == "1",
+        "coverage": float(form.get("coverage", 98)),
+        "use_ft": form.get("use_ft", "true") == "true",
+        "use_pt": form.get("use_pt", "true") == "true",
+        "allow_8h": form.get("allow_8h", "true") == "true",
+        "allow_10h8": form.get("allow_10h8", "true") == "true",
+        "allow_pt_4h": form.get("allow_pt_4h", "true") == "true",
+        "allow_pt_5h": form.get("allow_pt_5h", "false") == "true",
+        "allow_pt_6h": form.get("allow_pt_6h", "true") == "true",
+        "break_from_start": float(form.get("break_from_start", 2.5)),
+        "break_from_end": float(form.get("break_from_end", 2.5)),
+        "optimization_profile": form.get("optimization_profile", "JEAN"),
+        "profile": form.get("optimization_profile", "JEAN"),
+        "agent_limit_factor": 30,
+        "excess_penalty": 5.0,
+        "peak_bonus": 2.0,
+        "critical_bonus": 2.5,
+        "use_pulp": True,
+        "use_greedy": True,
+        "ft_first_pt_last": True,
+        "export_files": False,
+        "verbose": form.get("verbose") is not None,
     }
 
 @bp.route("/generador", methods=["GET", "POST"])

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -83,11 +83,11 @@
             <div class="row g-2 mt-2">
               <div class="col-6">
                 <label class="form-label">Break desde inicio (horas)</label>
-                <input class="form-control" type="number" step="0.5" name="break_from_start" value="2.0">
+                <input class="form-control" type="number" step="0.5" name="break_from_start" value="2.5">
               </div>
               <div class="col-6">
                 <label class="form-label">Break antes del fin (horas)</label>
-                <input class="form-control" type="number" step="0.5" name="break_from_end" value="2.0">
+                <input class="form-control" type="number" step="0.5" name="break_from_end" value="2.5">
               </div>
             </div>
           </div>

--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -5,7 +5,7 @@
 <!-- BANNER ÉXITO -->
 <div class="card mt-3">
   <div class="card-body d-flex align-items-center gap-3">
-    <span class="badge text-bg-success">Optimización completada</span>
+    <span class="badge text-bg-success">Optimización completada en {{ payload.meta.elapsed }}s</span>
     <span class="kpi-label">Perfil: <strong>{{ payload.config.optimization_profile }}</strong></span>
   </div>
 </div>
@@ -22,6 +22,12 @@
     <div class="card p-3">
       <div class="kpi">{{ m.coverage_percentage or 0 }}%</div>
       <div class="kpi-label">Cobertura Pura</div>
+    </div>
+  </div>
+  <div class="col-6 col-md-3">
+    <div class="card p-3">
+      <div class="kpi">{{ m.coverage_real or 0 }}%</div>
+      <div class="kpi-label">Cobertura Real</div>
     </div>
   </div>
   <div class="col-6 col-md-3">


### PR DESCRIPTION
## Summary
- Adjust JEAN search score to weight understaffing plus 30% of overstaffing
- Expose both pure and real coverage metrics and show them in the results UI
- Sync configuration defaults and breaks with Streamlit and show total runtime in results banner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba0ccdb1b8832789e56ecc5fe4f37d