### PR TITLE
Add contract counts and Excel export

### DIFF
--- a/website/templates/resultados.html
+++ b/website/templates/resultados.html
@@ -10,11 +10,22 @@
   </div>
 </div>
 
+{% if payload.export_b64 %}
+  <div class="mt-3">
+    <a class="btn btn-primary"
+       download="asignacion_turnos.xlsx"
+       href="data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,{{ payload.export_b64 }}">
+       Descargar Excel
+    </a>
+  </div>
+{% endif %}
+
 <!-- KPIs -->
 <div class="row g-3 mt-1">
   <div class="col-6 col-md-3">
-    <div class="card p-3">
-      <div class="kpi">{{ m.agents or 0 }}</div>
+    <div class="card p-3 text-center">
+      <div class="big-metric">{{ payload.agents_total }}</div>
+      <small>FT: {{ payload.contracts.ft }} · PT: {{ payload.contracts.pt }}</small>
       <div class="kpi-label">Total Agentes</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add contract counting and Excel export helpers
- include FT/PT totals and coverage metrics in sync payload
- display agent totals and add download button in results template

## Testing
- `pip install xlsxwriter`
- `pip install numpy flask`
- `pip install flask-wtf matplotlib`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f2de1f88327bdaa84b7bfcf6b98