### PR TITLE
feat: support new optimization profiles

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -14,6 +14,16 @@ def _is_on(form, *keys):
     return False
 
 
+def _get_profile_from_form(form):
+    # Acepta cualquiera de estos nombres tal como vienen del front
+    for k in ("optimization_profile", "profile", "perfil"):
+        v = form.get(k)
+        if v and str(v).strip():
+            return str(v).strip()
+    # Si no llega nada, usa un perfil neutral (no fuerces JEAN)
+    return "Equilibrado (Recomendado)"
+
+
 def _normalize_cfg_for_scheduler(form):
     # Toggles de tipo de contrato
     use_ft = _is_on(form, "use_ft", "allow_ft", "full_time", "ft")
@@ -71,11 +81,14 @@ def generador():
                 "break_before_end": float(form.get("break_to", 2.0)),
 
                 # perfil/solver
-                "optimization_profile": form.get("profile", "JEAN"),
                 "random_seed": 42,
                 "solver_threads": int(form.get("threads", 1)),
             }
         )
+
+        profile_name = _get_profile_from_form(form)
+        cfg["profile"] = profile_name
+        cfg["optimization_profile"] = profile_name
 
         cfg.update(_normalize_cfg_for_scheduler(form))
 

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -711,8 +711,15 @@ def run_complete_optimization(
     generate_charts=False,
     job_id=None,
     return_payload=False,
-):
+): 
     cfg = config or {}
+    # --- respeta el perfil si vino desde el front ---
+    if cfg.get("optimization_profile"):
+        pass  # ya viene bien
+    elif cfg.get("profile"):
+        cfg["optimization_profile"] = cfg["profile"]
+    else:
+        cfg["optimization_profile"] = "Equilibrado (Recomendado)"
     start_total = time.time()
     TIME_SOLVER = cfg.get("solver_time", 120) or None
     MAX_ITERS = int(cfg.get("iterations", 3))

--- a/website/templates/generador.html
+++ b/website/templates/generador.html
@@ -117,10 +117,19 @@
           <div>
             <strong>🎯 Perfil de Optimización</strong>
             <select class="form-select mt-2" name="optimization_profile">
-              <option selected>JEAN</option>
-              <option>Estándar</option>
+              <option selected>Equilibrado (Recomendado)</option>
+              <option>Conservador</option>
+              <option>Agresivo</option>
+              <option>Máxima Cobertura</option>
+              <option>Mínimo Costo</option>
+              <option>100% Cobertura Eficiente</option>
+              <option>100% Cobertura Total</option>
+              <option>Cobertura Perfecta</option>
+              <option>100% Exacto</option>
+              <option>Personalizado</option>
               <option>Aprendizaje Adaptativo</option>
-              <option>Greedy</option>
+              <option>JEAN</option>
+              <option>JEAN Personalizado</option>
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- handle profile selection robustly and default to neutral profile
- ensure scheduler picks optimization profile consistently
- expose complete optimization profile list to the frontend

## Testing
- `pytest` *(fails: No module named 'flask'; No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68ba6142ea548327bb8caf4f6a5427b3