### PR TITLE
Normalize generator family flag handling

### DIFF
--- a/website/generator_routes.py
+++ b/website/generator_routes.py
@@ -4,12 +4,13 @@ from .scheduler import run_complete_optimization as run_opt
 bp = Blueprint("generator", __name__)
 
 
-def _is_on(form, *keys):
-    for k in keys:
-        v = form.get(k)
-        if isinstance(v, str) and v.lower() in ("on", "true", "1", "yes"):
-            return True
-        if v is True:
+def _is_on(form, *names):
+    """Devuelve True si CUALQUIERA de los nombres llega encendido en el form."""
+    for n in names:
+        v = form.get(n)
+        if v is None:
+            continue
+        if str(v).lower() in ("on", "true", "1", "yes"):
             return True
     return False
 
@@ -24,85 +25,66 @@ def _get_profile_from_form(form):
     return "Equilibrado (Recomendado)"
 
 
-def _normalize_cfg_for_scheduler(form):
-    # Toggles de tipo de contrato
-    use_ft = _is_on(form, "use_ft", "allow_ft", "full_time", "ft")
-    use_pt = _is_on(form, "use_pt", "allow_pt", "part_time", "pt")
-
-    # Familias FT esperadas por el scheduler
-    allow_8h = use_ft and _is_on(form, "allow_8h", "ft_8h", "ft_8h6d", "ft8")
-    allow_10h8 = use_ft and _is_on(
-        form, "allow_10h8", "ft_10h5d", "ft_10h_5d", "ft_10h"
-    )
-
-    # Familias PT esperadas por el scheduler
-    allow_pt_4h = use_pt and _is_on(form, "allow_pt_4h", "pt_4h6d", "pt_4h")
-    allow_pt_5h = use_pt and _is_on(form, "allow_pt_5h", "pt_5h5d", "pt_5h")
-    allow_pt_6h = use_pt and _is_on(form, "allow_pt_6h", "pt_6h5d", "pt_6h4d", "pt_6h")
-
-    # Seguridad: si el usuario no activa ningún tipo, mantenemos el comportamiento antiguo
-    if not (use_ft or use_pt):
-        use_ft = True
-        use_pt = True
-
-    # Seguridad: si no activó ninguna familia, caemos al mínimo seguro (8h FT + 4h PT)
-    if not (allow_8h or allow_10h8 or allow_pt_4h or allow_pt_5h or allow_pt_6h):
-        allow_8h = use_ft
-        allow_pt_4h = use_pt
-
-    return {
-        "use_ft": use_ft,
-        "use_pt": use_pt,
-        "allow_8h": allow_8h,
-        "allow_10h8": allow_10h8,
-        "allow_pt_4h": allow_pt_4h,
-        "allow_pt_5h": allow_pt_5h,
-        "allow_pt_6h": allow_pt_6h,
-    }
-
-
 @bp.route("/generador", methods=["GET", "POST"])
 def generador():
     if request.method == "POST":
         form = request.form
 
-        cfg = {k: (str(v).lower() in ("on", "true", "1", "yes")) for k, v in form.items()}
+        cfg = {
+            # núcleo
+            "iterations": int(form.get("max_iters", 30)),
+            "solver_time": int(form.get("solver_time", 240)),
+            "solver_msg": _is_on(form, "verbose"),
+            "target_coverage": int(form.get("target_coverage", 98)),
 
-        cfg.update(
-            {
-                # núcleo
-                "iterations": int(form.get("max_iters", 30)),
-                "solver_time": int(form.get("solver_time", 240)),
-                "solver_msg": _is_on(form, "verbose"),
-                "target_coverage": int(form.get("target_coverage", 98)),
+            # breaks
+            "break_start_from": float(form.get("break_from", 2.0)),
+            "break_before_end": float(form.get("break_to", 2.0)),
 
-                # breaks
-                "break_start_from": float(form.get("break_from", 2.0)),
-                "break_before_end": float(form.get("break_to", 2.0)),
-
-                # perfil/solver
-                "random_seed": 42,
-                "solver_threads": int(form.get("threads", 1)),
-            }
-        )
+            # perfil/solver
+            "random_seed": 42,
+            "solver_threads": int(form.get("threads", 1)),
+        }
 
         profile_name = _get_profile_from_form(form)
         cfg["profile"] = profile_name
         cfg["optimization_profile"] = profile_name
 
-        cfg.update(_normalize_cfg_for_scheduler(form))
+        # === NORMALIZACIÓN DE FAMILIAS ===
+        cfg.update(
+            {
+                # Habilitar FT/PT (contratos)
+                "use_ft": _is_on(form, "allow_ft", "full_time", "use_ft"),
+                "use_pt": _is_on(form, "allow_pt", "part_time", "use_pt"),
 
-        for k in [
-            "full_time",
-            "part_time",
-            "ft_8h",
-            "ft_10h5d",
-            "pt_4h6d",
-            "pt_6h4d",
-            "pt_6h5d",
-            "pt_5h5d",
-        ]:
-            cfg.pop(k, None)
+                # Familias FT
+                "ft_8h": _is_on(form, "ft_8h", "allow_8h", "ft_8h6d"),
+                "ft_10h5d": _is_on(form, "ft_10h5d", "allow_10h8", "ft_10h"),
+
+                # Familias PT
+                "pt_4h6d": _is_on(form, "pt_4h6d", "allow_pt_4h"),
+                "pt_5h5d": _is_on(form, "pt_5h5d", "allow_pt_5h"),
+                "pt_6h4d": _is_on(form, "pt_6h4d", "allow_pt_6h"),
+            }
+        )
+
+        # Solo si el usuario NO seleccionó ninguna familia, activamos un set seguro
+        familias = ["ft_8h", "ft_10h5d", "pt_4h6d", "pt_5h5d", "pt_6h4d"]
+        if not any(cfg.get(k) for k in familias):
+            cfg["ft_8h"] = True
+            cfg["pt_4h6d"] = True
+            cfg["pt_6h4d"] = True
+            print("[GEN] fallback aplicado: ft_8h + pt_4h6d + pt_6h4d")
+
+        # (Opcional) si tu otra variante del scheduler espera las claves "allow_*", duplicamos:
+        cfg["allow_8h"] = cfg["ft_8h"]
+        cfg["allow_10h8"] = cfg["ft_10h5d"]
+        cfg["allow_pt_4h"] = cfg["pt_4h6d"]
+        cfg["allow_pt_5h"] = cfg["pt_5h5d"]
+        cfg["allow_pt_6h"] = cfg["pt_6h4d"]
+
+        # DEBUG: imprime qué familias quedaron realmente activas
+        print("[GEN] familias activas:", [f for f in familias if cfg.get(f)])
 
         xls = request.files.get("file")
         if not xls:


### PR DESCRIPTION
## Summary
- add flexible `_is_on` helper to accept multiple checkbox names
- map checkbox inputs to scheduler family flags with fallback and debug

## Testing
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pip install flask numpy`
- `pip install Flask-WTF matplotlib`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb570f31a08327950ec0cb61c43789