### PR TITLE
Fix profile overrides and shift selection

### DIFF
--- a/website/profiles.py
+++ b/website/profiles.py
@@ -102,34 +102,35 @@ PROFILES = {
 def apply_profile(cfg=None):
     """Aplicar perfil de optimización sobre la configuración."""
     from .scheduler_core import merge_config
-    
+
+    # 1) Rellenar con defaults
     cfg = merge_config(cfg)
-    profile = cfg.get("optimization_profile", "Equilibrado (Recomendado)")
-    
-    print(f"[PROFILE] Aplicando perfil: {profile}")
-    
-    # Obtener parámetros del perfil
-    profile_params = PROFILES.get(profile)
-    
-    if profile_params:
-        # Aplicar todos los parámetros del perfil
-        for key, val in profile_params.items():
-            if key not in cfg or cfg[key] is None:
-                cfg[key] = val
-        
+
+    # 2) Aplicar perfil seleccionado
+    profile_name = cfg.get("optimization_profile") or "Equilibrado (Recomendado)"
+    print(f"[PROFILE] Aplicando perfil: {profile_name}")
+    params = PROFILES.get(profile_name, {})
+
+    # 3) El perfil sobrescribe siempre
+    if params:
+        cfg.update(params)
+
         # Configuraciones específicas por perfil
-        if profile == "JEAN":
+        if profile_name == "JEAN":
             cfg["optimization_profile"] = "JEAN"
             cfg["use_jean_search"] = True
-            print(f"[PROFILE] JEAN: factor={cfg['agent_limit_factor']}, penalty={cfg['excess_penalty']}, target={cfg.get('TARGET_COVERAGE', 98)}%")
-        
-        elif profile == "JEAN Personalizado":
+            print(
+                f"[PROFILE] JEAN: factor={cfg['agent_limit_factor']}, penalty={cfg['excess_penalty']}, target={cfg.get('TARGET_COVERAGE', 98)}%"
+            )
+        elif profile_name == "JEAN Personalizado":
             cfg["optimization_profile"] = "JEAN Personalizado"
             cfg["use_jean_search"] = True
             print(f"[PROFILE] JEAN Personalizado configurado")
-        
+
         print(f"[PROFILE] Configuración aplicada - Strategy: {cfg.get('strategy', 'default')}")
     else:
-        print(f"[PROFILE] ADVERTENCIA: Perfil '{profile}' no encontrado, usando configuración por defecto")
-    
+        print(
+            f"[PROFILE] ADVERTENCIA: Perfil '{profile_name}' no encontrado, usando configuración por defecto"
+        )
+
     return cfg

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -686,11 +686,11 @@ def _insights_from_analysis(analysis, cfg):
     ]
 
     pt = []
-    if cfg.get("allow_pt", True) and cfg.get("pt_4h6d"):
+    if cfg.get("use_pt", True) and cfg.get("allow_pt_4h"):
         pt.append("4h×6días")
-    if cfg.get("allow_pt", True) and cfg.get("pt_6h4d"):
+    if cfg.get("use_pt", True) and cfg.get("allow_pt_6h"):
         pt.append("6h×4días")
-    if cfg.get("allow_pt", True) and cfg.get("pt_5h5d"):
+    if cfg.get("use_pt", True) and cfg.get("allow_pt_5h"):
         pt.append("5h×5días")
     ins["pt_habilitados"].append(", ".join(pt) if pt else "—")
 
@@ -848,15 +848,15 @@ def run_complete_optimization(
     demand_matrix = load_demand_matrix_from_df(df)
     analysis = _analyze_demand(demand_matrix)
     patterns = {}
-    allow_ft = cfg.get("allow_ft", True)
-    allow_pt = cfg.get("allow_pt", True)
+    use_ft = cfg.get("use_ft", True)
+    use_pt = cfg.get("use_pt", True)
     for batch in generate_shifts_coverage_optimized(
         demand_matrix,
-        allow_8h=allow_ft and cfg.get("ft_8h", True),
-        allow_10h8=allow_ft and cfg.get("ft_10h5d", True),
-        allow_pt_4h=allow_pt and cfg.get("pt_4h6d", True),
-        allow_pt_5h=allow_pt and cfg.get("pt_5h5d", True),
-        allow_pt_6h=allow_pt and cfg.get("pt_6h4d", True),
+        allow_8h=use_ft and cfg.get("allow_8h", False),
+        allow_10h8=use_ft and cfg.get("allow_10h8", False),
+        allow_pt_4h=use_pt and cfg.get("allow_pt_4h", False),
+        allow_pt_5h=use_pt and cfg.get("allow_pt_5h", False),
+        allow_pt_6h=use_pt and cfg.get("allow_pt_6h", False),
     ):
         patterns.update(batch)
 


### PR DESCRIPTION
## Summary
- Apply optimization profiles by overwriting defaults
- Apply profile and JEAN JSON overrides in generator route
- Generate shifts only for user-enabled turn families

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b205fd083278d9240b862ab899e