### PR TITLE
Respect profile penalties in precision optimizer

### DIFF
--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -431,7 +431,11 @@ def optimize_with_precision_targeting(
     total_def = pulp.lpSum(deficit_vars.values())
     total_exc = pulp.lpSum(excess_vars.values())
     total_agents = pulp.lpSum(shift_vars.values())
-    prob += total_def + 0.5 * total_exc + 0.001 * total_agents
+
+    def_pen = float(cfg.get("deficit_penalty", 1.0))
+    exc_pen = float(cfg.get("excess_penalty", 0.5))
+    agent_w = float(cfg.get("agent_weight", 0.001))
+    prob += def_pen * total_def + exc_pen * total_exc + agent_w * total_agents
 
     for d in range(7):
         for h in range(hours):


### PR DESCRIPTION
## Summary
- Use deficit, excess and agent weights from configuration in `optimize_with_precision_targeting`
- Keep scheduler’s precision optimizer as a single canonical implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7351b46083278b5a28bf6868da89