### PR TITLE
Robust profile optimizer import and pattern filtering

### DIFF
--- a/website/profile_optimizers.py
+++ b/website/profile_optimizers.py
@@ -22,12 +22,35 @@ except ImportError:
     PULP_AVAILABLE = False
 
 from . import scheduler
-from .scheduler import (
-    merge_config, single_model, analyze_results,
-    optimize_schedule_greedy_enhanced, optimize_with_precision_targeting,
-    get_adaptive_params, save_execution_result, load_shift_patterns,
-    optimize_ft_then_pt_strategy, _write_partial_result
-)
+
+try:
+    from .scheduler import (
+        merge_config,
+        single_model,
+        analyze_results,
+        optimize_schedule_greedy_enhanced,
+        optimize_with_precision_targeting,
+        get_adaptive_params,
+        save_execution_result,
+        load_shift_patterns,
+        optimize_ft_then_pt_strategy,
+        _write_partial_result,
+        optimize_jean_search,
+    )
+except Exception:  # pragma: no cover
+    from scheduler import (
+        merge_config,
+        single_model,
+        analyze_results,
+        optimize_schedule_greedy_enhanced,
+        optimize_with_precision_targeting,
+        get_adaptive_params,
+        save_execution_result,
+        load_shift_patterns,
+        optimize_ft_then_pt_strategy,
+        _write_partial_result,
+        optimize_jean_search,
+    )
 
 _sched_sig = inspect.signature(scheduler.optimize_jean_search)
 _TARGET_COVERAGE_DEFAULT = _sched_sig.parameters["target_coverage"].default


### PR DESCRIPTION
## Summary
- Load profile optimizers robustly with chunk fallback and apply PID filtering after JEAN search
- Use selected optimization profiles during scheduling and filter assignments by allowed pattern IDs
- Pass explicit solver parameters in profile optimizer wrappers and support direct scheduler imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc8b313ed083278bd81e73c5f456e8