### PR TITLE
Honor profile-specific optimizers and enforce pattern filters

### DIFF
--- a/website/profile_optimizers.py
+++ b/website/profile_optimizers.py
@@ -623,8 +623,8 @@ def optimize_jean_search(
         and "TARGET_COVERAGE" in cfg
     ):
         target_coverage = cfg["TARGET_COVERAGE"]
-    if max_iterations == _MAX_ITERATIONS_DEFAULT and "max_iterations" in cfg:
-        max_iterations = cfg["max_iterations"]
+    if max_iterations == _MAX_ITERATIONS_DEFAULT and "iterations" in cfg:
+        max_iterations = cfg["iterations"]
 
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
@@ -684,7 +684,7 @@ def optimize_jean_personalizado(shifts_coverage, demand_matrix, *, cfg=None):
                     shifts_coverage,
                     demand_matrix,
                     target_coverage=target,
-                    max_iterations=cfg.get("max_iterations", 5),
+                    max_iterations=cfg.get("iterations", 30),
                     agent_limit_factor=cfg["agent_limit_factor"],
                     excess_penalty=cfg["excess_penalty"],
                     peak_bonus=cfg["peak_bonus"],
@@ -701,7 +701,7 @@ def optimize_jean_personalizado(shifts_coverage, demand_matrix, *, cfg=None):
             shifts_coverage,
             demand_matrix,
             target_coverage=cfg.get("TARGET_COVERAGE", 98.0),
-            max_iterations=cfg.get("max_iterations", 5),
+            max_iterations=cfg.get("iterations", 30),
             agent_limit_factor=cfg["agent_limit_factor"],
             excess_penalty=cfg["excess_penalty"],
             peak_bonus=cfg["peak_bonus"],


### PR DESCRIPTION
## Summary
- Add robust import and fallback for profile optimizer selector
- Respect config iteration limits when running JEAN search
- Filter assignments by allowed FT/PT patterns and fallback to chunk solver on errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc8f8df51c8327a53d4dcd4c869ac6