### PR TITLE
Handle profile aliases and correct penalty objective

### DIFF
--- a/tests/profile_regression.py
+++ b/tests/profile_regression.py
@@ -53,7 +53,7 @@ def run_for_profile(profile, demand_matrix, shifts_coverage):
 if __name__ == "__main__":
     dm, sc = make_demand_matrix_from_legacy()
     results = []
-    for p in ["100% Exacto", "100% Cobertura Eficiente", "100% Cobertura Total", "JEAN"]:
+    for p in ["100% Exacto", "100% Cobertura Eficiente", "Cobertura Perfecta", "JEAN"]:
         results.append(run_for_profile(p, dm, sc))
     import csv
     with open(f"{LEGACY_DIR}/profile_regression.csv", "w", newline="", encoding="utf-8") as f:

--- a/website/optimizer_pulp.py
+++ b/website/optimizer_pulp.py
@@ -98,30 +98,30 @@ def optimize_with_pulp(shifts_coverage, demand_matrix, *, cfg=None, job_id=None)
         total_excess = pl.lpSum([excess_vars[(day, hour)] for day in range(7) for hour in range(hours)])
         total_agents = pl.lpSum([shift_vars[shift] for shift in shifts_list])
         
-        # Bonificaciones por días críticos y horas pico EXACTAS del original
-        critical_bonus_value = 0
-        peak_bonus_value = 0
+        # Penalizaciones por días críticos y horas pico
+        critical_penalty_value = 0
+        peak_penalty_value = 0
         
         # Días críticos
         for critical_day in critical_days:
             if critical_day < 7:
                 for hour in range(hours):
                     if demand_matrix[critical_day, hour] > 0:
-                        critical_bonus_value -= deficit_vars[(critical_day, hour)] * cfg["critical_bonus"]
+                        critical_penalty_value += deficit_vars[(critical_day, hour)] * cfg["critical_bonus"]
         
         # Horas pico
         for hour in peak_hours:
             if hour < hours:
                 for day in range(7):
                     if demand_matrix[day, hour] > 0:
-                        peak_bonus_value -= deficit_vars[(day, hour)] * cfg["peak_bonus"]
+                        peak_penalty_value += deficit_vars[(day, hour)] * cfg["peak_bonus"]
         
         # Función objetivo EXACTA del original
         prob += (total_deficit * 1000 + 
                  total_excess * cfg["excess_penalty"] + 
-                 total_agents * 0.1 + 
-                 critical_bonus_value + 
-                 peak_bonus_value)
+                 total_agents * 0.1 +
+                 critical_penalty_value +
+                 peak_penalty_value)
         
         # Restricciones de cobertura EXACTAS del original
         for day in range(7):

--- a/website/profiles.py
+++ b/website/profiles.py
@@ -107,8 +107,10 @@ def apply_profile(cfg=None):
     cfg = merge_config(cfg)
 
     # 2) Aplicar perfil seleccionado
-    profile_name = cfg.get("optimization_profile") or "Equilibrado (Recomendado)"
-    profile_name = normalize_profile(profile_name)
+    requested = cfg.get("optimization_profile") or "Equilibrado (Recomendado)"
+    profile_name = resolve_profile_name(requested) or requested
+    if profile_name != requested:
+        print(f"[PROFILE] Usando alias '{requested}' -> '{profile_name}'")
     print(f"[PROFILE] Aplicando perfil: {profile_name}")
     params = PROFILES.get(profile_name, {})
 
@@ -143,12 +145,19 @@ def apply_profile(cfg=None):
 
 # --- ALIASES para nombres de UI ---
 ALIASES = {
-    "100% Exacto": "Cobertura Exacta",
-    "100% Cobertura Eficiente": "Cobertura Eficiente 100",
-    "100% Cobertura Total": "Cobertura Total 100",
-    "Aprendizaje Adaptativo": "Adaptativo-Recomendado",
+    "100% Exacto": "Máxima Cobertura",
+    "100% Cobertura Eficiente": "Máxima Cobertura",
+    "Cobertura Perfecta": "Máxima Cobertura",
 }
 
 
+def resolve_profile_name(name: str) -> str:
+    if not name:
+        return None
+    if name in PROFILES:
+        return name
+    return ALIASES.get(name)
+
+
 def normalize_profile(name: str) -> str:
-    return ALIASES.get(name, name)
+    return resolve_profile_name(name) or name

--- a/website/scheduler.py
+++ b/website/scheduler.py
@@ -21,9 +21,9 @@ except Exception:  # pragma: no cover
     current_app = None
 
 try:
-    from .profiles import normalize_profile
+    from .profiles import PROFILES, resolve_profile_name
 except Exception:  # pragma: no cover
-    from website.profiles import normalize_profile
+    from website.profiles import PROFILES, resolve_profile_name
 
 # === Robust import of profile optimizer selector ===
 try:
@@ -1112,13 +1112,23 @@ def run_complete_optimization(
     return_payload=False,
 ): 
     cfg = config or {}
-    # --- respeta el perfil si vino desde el front ---
-    if cfg.get("optimization_profile"):
-        pass  # ya viene bien
-    elif cfg.get("profile"):
-        cfg["optimization_profile"] = cfg["profile"]
+    requested = (
+        cfg.get("optimization_profile")
+        or cfg.get("profile")
+        or "Equilibrado (Recomendado)"
+    )
+    resolved = resolve_profile_name(requested)
+    if resolved and resolved != requested:
+        print(f"[PROFILE] Usando alias '{requested}' -> '{resolved}'")
+    profile_params = PROFILES.get(resolved)
+    if not profile_params:
+        print(
+            f"[PROFILE] ADVERTENCIA: Perfil '{requested}' no encontrado, usando configuración por defecto"
+        )
     else:
-        cfg["optimization_profile"] = "Equilibrado (Recomendado)"
+        for k, v in profile_params.items():
+            cfg.setdefault(k, v)
+    cfg["optimization_profile"] = resolved or requested
     optimization_profile = cfg.get("optimization_profile", "")
 
     # Alias para iteraciones: UI usa 'iterations', perfil usa 'search_iterations'
@@ -1230,7 +1240,7 @@ def run_complete_optimization(
         )
         assignments = {k: v for k, v in (assignments or {}).items() if _is_allowed_pid(k, cfg)}
     else:
-        normalized = normalize_profile(optimization_profile or "")
+        normalized = resolve_profile_name(optimization_profile or "") or optimization_profile
         print(
             f"[SCHEDULER] Ejecutando perfil estándar con optimizador dedicado: {normalized}"
         )


### PR DESCRIPTION
## Summary
- Add `resolve_profile_name` helper and alias mappings for alternate profile names
- Resolve aliases when applying configuration and warn on unknown profiles
- Penalize deficits in critical days and peak hours instead of rewarding them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf648bf47c832790b72376c0052bf9